### PR TITLE
feat(core): add multipart-form-data

### DIFF
--- a/.bruno/vercube-bruno-collection/playground/Upload.bru
+++ b/.bruno/vercube-bruno-collection/playground/Upload.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Upload
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{url}}/api/playground/upload
+  body: multipartForm
+  auth: none
+}
+
+body:multipart-form {
+  logo: @file(/Users/olebuda/projects/vercube/.github/assets/logo.png)
+}

--- a/packages/core/src/Decorators/Http/MultipartFormData.ts
+++ b/packages/core/src/Decorators/Http/MultipartFormData.ts
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import { BaseDecorator, createDecorator } from '@vercube/di';
+import { MetadataTypes } from '../../Types/MetadataTypes';
+import { initializeMetadata, initializeMetadataMethod } from '../../Utils/Utils';
+
+/**
+ * @class MultipartFormDataDecorator
+ * @extends BaseDecorator<MultipartFormDataOptions>
+ *
+ * A decorator class that handles the metadata for HTTP request bodies.
+ */
+class MultipartFormDataDecorator extends BaseDecorator<{}, MetadataTypes.Metadata> {
+
+  /**
+   * @method created
+   * This method is called when the decorator is created. It ensures that the metadata
+   * for the property exists and adds the body argument to the metadata.
+   */
+  public override created(): void {
+    initializeMetadata(this.prototype);
+    const method = initializeMetadataMethod(this.prototype, this.propertyName);
+
+    method.args.push({
+      idx: this.propertyIndex,
+      type: 'multipart-form-data',
+    });
+
+  }
+
+}
+
+/**
+ * Decorator function that marks a parameter as multipart/form-data request body.
+ * This decorator will automatically parse incoming multipart form data
+ * 
+ * @decorator
+ * @returns {Function} A decorator function that can be applied to method parameters
+ * 
+ * @example
+ * class UserController {
+ *   uploadFile(@MultipartFormData() formData: MyData) {
+ *     // Handle multipart form data
+ *   }
+ * }
+ */
+
+export function MultipartFormData(): Function {
+  return createDecorator(MultipartFormDataDecorator, {});
+}

--- a/packages/core/src/Services/Metadata/MetadataResolver.ts
+++ b/packages/core/src/Services/Metadata/MetadataResolver.ts
@@ -1,4 +1,4 @@
-import { getHeader, getHeaders, getQuery, getRouterParam, readBody } from 'h3';
+import { getHeader, getHeaders, getQuery, getRouterParam, readBody, readMultipartFormData } from 'h3';
 import type { MetadataTypes } from '../../Types/MetadataTypes';
 import type { HttpEvent } from '../../Types/CommonTypes';
 
@@ -87,6 +87,9 @@ export class MetadataResolver {
       }
       case 'body': {
         return readBody(event);
+      }
+      case 'multipart-form-data': {
+        return readMultipartFormData(event);
       }
       case 'query-param': {
         const query = getQuery(event);

--- a/packages/core/src/Types/CommonTypes.ts
+++ b/packages/core/src/Types/CommonTypes.ts
@@ -1,4 +1,4 @@
-import type { H3Event } from 'h3';
+import type { H3Event, MultiPartData as H3MultiPartData } from 'h3';
 import { MetadataTypes } from './MetadataTypes';
 
 /**
@@ -11,3 +11,5 @@ export interface MiddlewareOptions<T = unknown> {
   middlewareArgs?: T;
   methodArgs?: MetadataTypes.Arg[];
 }
+
+export type MultiPartData = H3MultiPartData;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export * from './Decorators/Http/SetHeader';
 export * from './Decorators/Http/Status';
 export * from './Decorators/Http/Redirect';
 export * from './Decorators/Http/Middleware';
+export * from './Decorators/Http/MultipartFormData';
 
 // Hooks
 export * from './Decorators/Hooks/Listen';

--- a/playground/src/Controllers/PlaygroundController.ts
+++ b/playground/src/Controllers/PlaygroundController.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Middleware, SetHeader, Status, HTTPStatus, Redirect, Post, Body, QueryParams } from '@vercube/core';
+import { Controller, Get, Middleware, SetHeader, Status, HTTPStatus, Redirect, Post, Body, QueryParams, MultipartFormData, MultiPartData } from '@vercube/core';
 import { Authenticate } from '@vercube/auth';
 import { FirstMiddleware } from '../Middlewares/FirstMiddleware';
 import { SecondMiddleware } from '../Middlewares/SecondMiddleware';
@@ -114,6 +114,18 @@ export default class PlaygroundController {
   @Status(HTTPStatus.OK)
   public async redirected(): Promise<{ message: string }> {
     return { message: 'Hello, im redirected!' };
+  }
+
+  /**
+   * Handles GET requests to the /upload endpoint.
+   * @returns {Promise<{ message: string }>} A promise that resolves to an object containing a greeting message.
+   */
+  @Post('/upload')
+  public async upload(@MultipartFormData() form: MultiPartData[]): Promise<{ message: string }> {
+
+    console.log(form);
+
+    return { message: 'Hello, world!' };
   }
 
 }


### PR DESCRIPTION
Add a `MultipartFormData` decorator for file uploading.

Example:
```typescript
/**
 * Handles GET requests to the /upload endpoint.
 * @returns {Promise<{ message: string }>} A promise that resolves to an object containing a greeting message.
 */
@Post('/upload')
public async upload(@MultipartFormData() form: MultiPartData[]): Promise<{ message: string }> {

  console.log(form);

  return { message: 'Hello, world!' };
}
```
