### PR TITLE
refactor: remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@swc-node/register": "^1.10.9",
     "@swc/core": "^1.11.5",
     "@swc/helpers": "^0.5.15",
-    "@types/lodash": "4.17.15",
     "@types/node": "22.13.5",
     "eslint": "9.21.0",
     "eslint-config-unjs": "0.4.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,10 +31,6 @@
     "c12": "^3.0.2",
     "defu": "^6.1.4",
     "h3": "1.15.1",
-    "listhen": "1.9.0",
-    "lodash": "4.17.21"
-  },
-  "devDependencies": {
-    "@types/lodash": "4.17.15"
+    "listhen": "1.9.0"
   }
 }

--- a/packages/core/src/Services/Hooks/HooksService.ts
+++ b/packages/core/src/Services/Hooks/HooksService.ts
@@ -21,7 +21,6 @@
  *
  * Everything 100% typechecked.
  */
-import remove from 'lodash/remove';
 import type { HooksTypes } from '../../Types/HooksTypes';
 
 /**
@@ -111,9 +110,9 @@ export class HooksService {
   /**
    * Removes listener from particular event.
    * @param eventId eventId returned from .on() method.
-   * @returns true if event was removed, false if it wasnt registered
+   * @throws Error if event was not registered
    */
-  public off<T>(eventId: HooksTypes.HookID): number {
+  public off<T>(eventId: HooksTypes.HookID): void {
 
     const type: HooksTypes.HookType<T> = eventId.__type;
     const handlersOfType: HooksTypes.HookHandler<T>[] | undefined = this.fHandlers.get(type);
@@ -122,14 +121,13 @@ export class HooksService {
       throw new Error('Trying to unbind event that was not bound.');
     }
 
-    const removed: HooksTypes.HookHandler<any>[] = remove(handlersOfType, (h) => h.id === eventId.__id);
+    const index = handlersOfType.findIndex(handler => handler.id === eventId.__id);
 
-    if (removed.length === 0) {
+    if (index === -1) {
       throw new Error('Trying to unbind event that was not bound.');
     }
 
-    return removed.length;
-
+    handlersOfType.splice(index, 1);
   }
 
   /**
@@ -178,11 +176,11 @@ export class HooksService {
 
         // copy all properties to convert it to class instance
 
-         
+
         const rawInstance: any = instance;
         const rawData: any = data;
         rawInstance[key] = rawData[key];
-         
+
 
       }
     }

--- a/playground/package.json
+++ b/playground/package.json
@@ -20,7 +20,6 @@
     "@vercube/di": "workspace:*",
     "@vercube/logger": "workspace:*",
     "@vercube/storage": "workspace:*",
-    "lodash": "4.17.21",
     "tslib": "2.7.0",
     "zod": "3.24.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@swc/helpers':
         specifier: ^0.5.15
         version: 0.5.15
-      '@types/lodash':
-        specifier: 4.17.15
-        version: 4.17.15
       '@types/node':
         specifier: 22.13.5
         version: 22.13.5
@@ -122,13 +119,6 @@ importers:
       listhen:
         specifier: 1.9.0
         version: 1.9.0
-      lodash:
-        specifier: 4.17.21
-        version: 4.17.21
-    devDependencies:
-      '@types/lodash':
-        specifier: 4.17.15
-        version: 4.17.15
 
   packages/devkit:
     dependencies:
@@ -233,9 +223,6 @@ importers:
       '@vercube/storage':
         specifier: workspace:*
         version: link:../packages/storage
-      lodash:
-        specifier: 4.17.21
-        version: 4.17.21
       tslib:
         specifier: 2.7.0
         version: 2.7.0
@@ -2264,9 +2251,6 @@ packages:
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
-  '@types/lodash@4.17.15':
-    resolution: {integrity: sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==}
-
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
 
@@ -3805,9 +3789,6 @@ packages:
 
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -7100,8 +7081,6 @@ snapshots:
 
   '@types/linkify-it@5.0.0': {}
 
-  '@types/lodash@4.17.15': {}
-
   '@types/markdown-it@14.1.2':
     dependencies:
       '@types/linkify-it': 5.0.0
@@ -8901,8 +8880,6 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash.upperfirst@4.3.1: {}
-
-  lodash@4.17.21: {}
 
   log-symbols@4.1.0:
     dependencies:


### PR DESCRIPTION
Removed the lodash dependency as it was only used for a simple array filter.
Reworked the `off` method of the `HooksService` to be void, as it only could return true in the previous implementation (while throwing error if the action was unsuccessful).
