### PR TITLE
refactor: rework middleware

### DIFF
--- a/packages/auth/src/Middleware/AuthenticationMiddleware.ts
+++ b/packages/auth/src/Middleware/AuthenticationMiddleware.ts
@@ -27,7 +27,7 @@ export class AuthenticationMiddleware implements BaseMiddleware {
    * @param {MiddlewareOptions} args - Additional arguments for the middleware
    * @returns {Promise<void>} - A promise that resolves when the processing is complete.
    */
-  public async use(event: HttpEvent, args?: MiddlewareOptions<AuthenticationTypes.MiddlewareOptions>): Promise<void> {
+  public async onRequest(event: HttpEvent, args: MiddlewareOptions<AuthenticationTypes.MiddlewareOptions>): Promise<void> {
     let provider = this.gAuthenticationProvider;
 
     if (args?.middlewareArgs?.provider) {

--- a/packages/auth/src/Middleware/AuthorizationMiddleware.ts
+++ b/packages/auth/src/Middleware/AuthorizationMiddleware.ts
@@ -32,7 +32,7 @@ export class AuthorizationMiddleware<T> implements BaseMiddleware {
    * @param {MiddlewareOptions} args - Additional arguments for the middleware
    * @returns {Promise<void>} - A promise that resolves when the processing is complete.
    */
-  public async use(
+  public async onRequest(
     event: HttpEvent,
     args: MiddlewareOptions<{options: AuthorizationTypes.MiddlewareOptions, params: T}>,
   ): Promise<void> {

--- a/packages/core/src/Decorators/Http/Middleware.ts
+++ b/packages/core/src/Decorators/Http/Middleware.ts
@@ -13,14 +13,14 @@ interface MiddlewareDecoratorParams extends Omit<MetadataTypes.Middleware, 'midd
  * @param opts.type - The type of middleware ('before' or 'after')
  * @param opts.priority - Priority order for middleware execution (default: 999)
  * @returns A decorator function that can be applied to classes or methods
- * 
+ *
  * @example
  * ```typescript
  * @Middleware(AuthMiddleware)
  * class UserController {
  *   // ...
  * }
- * 
+ *
  * // Or on a specific method:
  * @Middleware(ValidationMiddleware, { type: 'before', priority: 1 })
  * public async createUser() {
@@ -35,7 +35,6 @@ export function Middleware(middleware: typeof BaseMiddleware, opts?: MiddlewareD
 
     meta.__middlewares.push({
       target: propertyName ?? '__global__',
-      type: opts?.type ?? 'before',
       priority: opts?.priority ?? 999, // default priority is 999 to ensure it runs last
       middleware,
     });

--- a/packages/core/src/Middleware/ValidationMiddleware.ts
+++ b/packages/core/src/Middleware/ValidationMiddleware.ts
@@ -1,4 +1,4 @@
- 
+
 import { InjectOptional } from '@vercube/di';
 import { BaseMiddleware } from '../Services/Middleware/BaseMiddleware';
 import { HttpEvent, MiddlewareOptions } from '../Types/CommonTypes';
@@ -26,7 +26,7 @@ export class ValidationMiddleware implements BaseMiddleware {
    * @returns {Promise<void>} - A promise that resolves when the processing is complete
    * @throws {BadRequestError} - If validation fails
    */
-  public async use(event: HttpEvent, args: MiddlewareOptions): Promise<void> {
+  public async onRequest(event: HttpEvent, args: MiddlewareOptions): Promise<void> {
     if (!this.gValidationProvider) {
       console.warn('ValidationMiddleware::ValidationProvider is not registered');
       return;

--- a/packages/core/src/Services/Metadata/MetadataResolver.ts
+++ b/packages/core/src/Services/Metadata/MetadataResolver.ts
@@ -24,6 +24,10 @@ export class MetadataResolver {
     return url;
   }
 
+  public resolveMethod(ctx: MetadataTypes.Metadata, propertyName: string): MetadataTypes.Method {
+    return ctx.__metadata.__methods[propertyName];
+  }
+
   /**
    * Resolves metadata for a given event.
    *
@@ -33,7 +37,7 @@ export class MetadataResolver {
    * @return {Object} The resolved metadata.
    */
   public async resolve(event: HttpEvent, ctx: MetadataTypes.Metadata, propertyName: string): Promise<MetadataTypes.ResolvedData> {
-    const metadata = ctx.__metadata.__methods[propertyName];
+    const metadata = this.resolveMethod(ctx, propertyName);
     const args = await this.resolveArgs(metadata?.args ?? [], event);
 
     return {
@@ -52,9 +56,9 @@ export class MetadataResolver {
    * @param {MetadataTypes.Arg[]} args - The arguments to resolve.
    * @param {HttpEvent} event - The event to resolve arguments for.
    * @return {unknown[]} The resolved arguments.
-   * @private
+   * @public
    */
-  private async resolveArgs(args: MetadataTypes.Arg[], event: HttpEvent): Promise<MetadataTypes.Arg[]> {
+  public async resolveArgs(args: MetadataTypes.Arg[], event: HttpEvent): Promise<MetadataTypes.Arg[]> {
     // sort arguments by index
     args.sort((a, b) => a.idx - b.idx);
 
@@ -118,13 +122,13 @@ export class MetadataResolver {
 
   /**
    * Resolves middleware functions for a given context and property name.
-   * 
+   *
    * @param {MetadataTypes.Ctx} ctx - The metadata context object
    * @param {string} propertyName - The name of the property to resolve middlewares for
    * @returns {MetadataTypes.Middleware[]} Array of middleware functions that apply globally or to the specific property
-   * @private
+   * @public
    */
-  private resolveMiddlewares(ctx: MetadataTypes.Metadata, propertyName: string): MetadataTypes.Middleware[] {
+  public resolveMiddlewares(ctx: MetadataTypes.Metadata, propertyName: string): MetadataTypes.Middleware[] {
     const middlewares = ctx?.__metadata?.__middlewares?.filter((m) => m.target === '__global__' || m.target === propertyName) ?? [];
 
     // return middlewares sorted by global first

--- a/packages/core/src/Services/Middleware/BaseMiddleware.ts
+++ b/packages/core/src/Services/Middleware/BaseMiddleware.ts
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import type { HttpEvent, MiddlewareOptions } from '../../Types/CommonTypes';
 
 /**
  * BaseMiddleware class that serves as a base for all middleware implementations.
  */
-export class BaseMiddleware<T = unknown> {
+export class BaseMiddleware<T = unknown, U = unknown> {
 
   /**
    * Middleware function that processes the HTTP event.
@@ -16,6 +16,18 @@ export class BaseMiddleware<T = unknown> {
    * @param {T[]} args - Additional arguments for the middleware.
    * @returns {void | Promise<void>} - A void or a promise that resolves when the processing is complete.
    */
-  public use(event: HttpEvent, args?: MiddlewareOptions): void | Promise<void> {}
+  onRequest?(event: HttpEvent, args: MiddlewareOptions<T>): void | Promise<void>;
+
+  /**
+   * Middleware function that processes the response.
+   * This method should be overridden by subclasses to implement specific middleware logic.
+   * WARNING: This method cannot return a value, it will be ignored.
+   * Middleware can only modify the event object or throw an HttpError like BadRequestError, ForbiddenError, etc.
+   *
+   * @param {HttpEvent} event - The HTTP event to be processed.
+   * @param {unknown} response - The response from the controller.
+   * @returns {void | Promise<void>} - A void or a promise that resolves when the processing is complete.
+   */
+  onResponse?(event: HttpEvent, response: { body?: U }): void | Promise<void>;
 
 }

--- a/packages/core/src/Types/MetadataTypes.ts
+++ b/packages/core/src/Types/MetadataTypes.ts
@@ -1,4 +1,4 @@
- 
+
 import type { NodeEventContext } from 'h3';
 import type { BaseMiddleware } from '../Services/Middleware/BaseMiddleware';
 import { ValidationTypes } from './ValidationTypes';
@@ -52,7 +52,6 @@ export namespace MetadataTypes {
 
   export interface Middleware {
     target: string;
-    type?: 'before' | 'after';
     priority?: number;
     middleware: typeof BaseMiddleware;
     args?: unknown;

--- a/playground/src/Controllers/PlaygroundController.ts
+++ b/playground/src/Controllers/PlaygroundController.ts
@@ -21,6 +21,7 @@ import { Logger } from '@vercube/logger';
 import { BasicAuthenticationProvider } from '../Services/BasicAuthenticationProvider';
 import { AuthorizationParameters } from '../Types/AuthorizationParameters';
 import { DummyAuthorizationProvider } from '../Services/DummyAuthorizationProvider';
+import { SecondMiddleware } from '../Middlewares/SecondMiddleware';
 
 const schema = z.object({
   name: z.string().min(1, 'Name is required'),
@@ -53,6 +54,7 @@ export default class PlaygroundController {
    */
   @Get('/')
   @SetHeader('X-Test-Response-Header', '1')
+  @Middleware(SecondMiddleware)
   public async index(): Promise<{ message: string }> {
     this.gLogger.debug('PlaygroundController::index', 'Debug method');
     this.gLogger.info('PlaygroundController::index', 'Info method');

--- a/playground/src/Middlewares/FirstMiddleware.ts
+++ b/playground/src/Middlewares/FirstMiddleware.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { BadRequestError, BaseMiddleware, type HttpEvent } from '@vercube/core';
+import { BaseMiddleware, type HttpEvent } from '@vercube/core';
 
 /**
  * FirstMiddleware class that implements the BaseMiddleware interface.
@@ -12,7 +12,7 @@ export class FirstMiddleware implements BaseMiddleware {
    * @param {HttpEvent} event - The HTTP event to be processed.
    * @returns {Promise<void>} - A promise that resolves when the processing is complete.
    */
-  public async use(event: HttpEvent): Promise<void> {
+  public async onRequest(event: HttpEvent): Promise<void> {
     console.log('First middleware');
   }
 

--- a/playground/src/Middlewares/SecondMiddleware.ts
+++ b/playground/src/Middlewares/SecondMiddleware.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { BadRequestError, BaseMiddleware, type HttpEvent } from '@vercube/core';
+import { BaseMiddleware, type HttpEvent } from '@vercube/core';
 
 /**
  * SecondMiddleware class that implements the BaseMiddleware interface.
@@ -12,9 +11,8 @@ export class SecondMiddleware implements BaseMiddleware {
    * @param {HttpEvent} event - The HTTP event to be processed.
    * @returns {Promise<void>} - A promise that resolves when the processing is complete.
    */
-  public async use(event: HttpEvent): Promise<void> {
-    console.log('SecondMiddleware');
-    throw new BadRequestError('Unauthorized');
+  public async onResponse(event: HttpEvent, { body }: { body: any }): Promise<void> {
+    console.log(body);
   }
 
 }


### PR DESCRIPTION
Rework `Middleware` to be more universal.

Middlewares now run based on their available methods. If `onRequest` is defined, it is run before the controller as before. If `onResponse` is defined, it is run after the controller. It is now possible to modify the response body in `onResponse`.

Removed the `type` property from the middleware config options as it is not required anymore. This also opens up the possibility to use the same middleware class as both before and after.