### PR TITLE
feat(session): add session decorator

### DIFF
--- a/.bruno/vercube-bruno-collection/playground/Session.bru
+++ b/.bruno/vercube-bruno-collection/playground/Session.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Session
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{url}}/api/playground/session
+  body: none
+  auth: none
+}

--- a/packages/core/src/Config/DefaultConfig.ts
+++ b/packages/core/src/Config/DefaultConfig.ts
@@ -1,4 +1,5 @@
 import { ConfigTypes } from '../Types/ConfigTypes';
+import generateRandomHash from '../Utils/InternalUtils';
 
 /**
  * Default configuration for the Vercube application.
@@ -86,5 +87,25 @@ export const defaultConfig: ConfigTypes.Config = {
   /**
    * Empty runtime configuration
    */
-  runtime: {},
+  runtime: {
+    /**
+     * Session configuration options.
+     */
+    session: {
+      /**
+       * The secret used to sign the session ID cookie.
+       */
+      secret: process.env?.SECRET ?? generateRandomHash(),
+
+      /**
+       * The name of the session ID cookie.
+       */
+      name: 'vercube_session',
+
+      /**
+       * The duration of time for the session to be active.
+       */
+      duration: 60 * 60 * 24 * 7, // 7 days as default
+    },
+  },
 };

--- a/packages/core/src/Decorators/Http/Session.ts
+++ b/packages/core/src/Decorators/Http/Session.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import { BaseDecorator, createDecorator, Inject } from '@vercube/di';
+import { initializeMetadata, initializeMetadataMethod } from '../../Utils/Utils';
+import { RuntimeConfig } from '../../Services/Config/RuntimeConfig';
+import generateRandomHash from '../../Utils/InternalUtils';
+
+/**
+ * This class is responsible for managing session decorators.
+ *
+ * This class extends the BaseDecorator and is used to register session information
+ * with the MetadataResolver. It ensures that the metadata for the property is created
+ * and adds the session information to the metadata.
+ *
+ * @extends {BaseDecorator<{}>}
+ */
+class SessionDecorator extends BaseDecorator<{}> {
+
+  @Inject(RuntimeConfig)
+  private gRuntimeConfig: RuntimeConfig;
+
+  /**
+   * Called when the decorator is created.
+   *
+   * This method checks if metadata for the property exists, creates it if it doesn't,
+   * and then adds the session information to the metadata.
+   */
+  public override created(): void {
+    initializeMetadata(this.prototype);
+    const method = initializeMetadataMethod(this.prototype, this.propertyName);
+
+    method.args.push({
+      idx: this.propertyIndex,
+      type: 'session',
+      data: {
+        name: this.gRuntimeConfig.runtimeConfig.session?.name ?? 'vercube_session',
+        secret: this.gRuntimeConfig.runtimeConfig.session?.secret?? generateRandomHash(),
+        duration: this.gRuntimeConfig.runtimeConfig.session?.duration?? (60 * 60 * 24 * 7), // 7 days as default
+      },
+    });
+
+  }
+
+}
+
+/**
+ * A factory function for creating a SessionDecorator.
+ *
+ * This function returns a decorator function that can be used to annotate
+ * a method parameter with session information.
+ *
+ * @return {Function} The decorator function.
+ */
+export function Session(): Function {
+  return createDecorator(SessionDecorator, {});
+}

--- a/packages/core/src/Services/Metadata/MetadataResolver.ts
+++ b/packages/core/src/Services/Metadata/MetadataResolver.ts
@@ -1,4 +1,4 @@
-import { getHeader, getHeaders, getQuery, getRouterParam, readBody, readMultipartFormData } from 'h3';
+import { getHeader, getHeaders, getQuery, getRouterParam, readBody, readMultipartFormData, useSession } from 'h3';
 import type { MetadataTypes } from '../../Types/MetadataTypes';
 import type { HttpEvent } from '../../Types/CommonTypes';
 
@@ -113,6 +113,17 @@ export class MetadataResolver {
       }
       case 'response': {
         return event.node.res;
+      }
+      case 'session': {
+        return useSession(event, {
+          name: arg?.data?.name,
+          password: arg?.data?.secret,
+          cookie: {
+            httpOnly: true,
+            secure: true,
+          },
+          maxAge: arg?.data?.duration,
+        });
       }
       default: {
         throw new Error(`Unknown argument type: ${arg.type}`);

--- a/packages/core/src/Types/CommonTypes.ts
+++ b/packages/core/src/Types/CommonTypes.ts
@@ -1,4 +1,5 @@
-import type { H3Event, MultiPartData as H3MultiPartData } from 'h3';
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import type { H3Event, MultiPartData as H3MultiPartData, SessionData as H3SessionData } from 'h3';
 import { MetadataTypes } from './MetadataTypes';
 
 /**
@@ -7,6 +8,14 @@ import { MetadataTypes } from './MetadataTypes';
  */
 export type HttpEvent = H3Event;
 
+export type SessionData<T extends H3SessionData = {}> = H3SessionData<T>;
+type SessionUpdate<T extends SessionData = SessionData> = Partial<SessionData<T>> | ((oldData: SessionData<T>) => Partial<SessionData<T>> | undefined);
+export interface SessionEvent<T extends H3SessionData = {}> {
+  readonly id: any;
+  readonly data: T;
+  update: (update: SessionUpdate<T>) => Promise<any>;
+  clear: () => Promise<any>;
+}
 export interface MiddlewareOptions<T = unknown> {
   middlewareArgs?: T;
   methodArgs?: MetadataTypes.Arg[];

--- a/packages/core/src/Types/ConfigTypes.ts
+++ b/packages/core/src/Types/ConfigTypes.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-import type { LoggerTypes } from '@vercube/logger';
- 
+import type { LoggerTypes } from '@vercube/logger'; 
 /**
  * Namespace containing configuration type definitions for the Vercube framework.
  */
@@ -10,7 +9,25 @@ export namespace ConfigTypes {
    * Runtime configuration interface that can be modified during application execution.
    */
   export interface RuntimeConfig {
-    // add runtime config here
+    /**
+     * Session configuration options.
+     */
+    session?: {
+      /**
+       * The secret used to sign the session ID cookie.
+       */
+      secret?: string;
+
+      /**
+       * The name of the session ID cookie.
+       */
+      name?: string;
+
+      /**
+       * The duration of time for the session to be active.
+       */
+      duration?: number;
+    }
   }
 
   /**

--- a/packages/core/src/Utils/InternalUtils.ts
+++ b/packages/core/src/Utils/InternalUtils.ts
@@ -1,0 +1,10 @@
+/**
+ * Generate random hash
+ * @returns string
+ */
+export default function generateRandomHash(): string {
+  const hashByPerformance = Math.floor(Date.now() * 1000).toString(16);
+   
+  const hashByMath = (): string => ((Math.floor(Math.random() * 0xFF_FF_FF) | 0x10_00_00).toString(16));
+  return `${hashByPerformance}-${hashByMath()}-${hashByMath()}-${hashByMath()}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export * from './Decorators/Http/Status';
 export * from './Decorators/Http/Redirect';
 export * from './Decorators/Http/Middleware';
 export * from './Decorators/Http/MultipartFormData';
+export * from './Decorators/Http/Session';
 
 // Hooks
 export * from './Decorators/Hooks/Listen';

--- a/playground/src/Controllers/PlaygroundController.ts
+++ b/playground/src/Controllers/PlaygroundController.ts
@@ -11,6 +11,8 @@ import {
   QueryParams,
   MultipartFormData,
   MultiPartData,
+  Session,
+  SessionEvent,
 } from '@vercube/core';
 import { Authenticate, Authorize } from '@vercube/auth';
 import { FirstMiddleware } from '../Middlewares/FirstMiddleware';
@@ -167,6 +169,23 @@ export default class PlaygroundController {
   public async upload(@MultipartFormData() form: MultiPartData[]): Promise<{ message: string }> {
 
     console.log(form);
+
+    return { message: 'Hello, world!' };
+  }
+
+  /**
+   * Handles GET requests to the /session endpoint.
+   * @returns {Promise<{ message: string }>} A promise that resolves to an object containing a greeting message.
+   */
+  @Get('/session')
+  public async session(@Session() session: SessionEvent<{ count: number }>): Promise<{ message: string }> {
+    const count = (session.data.count || 0) + 1;
+
+    await session.update({
+      count: count,
+    });
+
+    console.log(session.data);
 
     return { message: 'Hello, world!' };
   }


### PR DESCRIPTION
Add missing `@Session` decorator for Core.

## Usage:
```typescript
@Get('/session')
public async session(@Session() session: SessionEvent<{ count: number }>): Promise<{ message: string }> {
  const count = (session.data.count || 0) + 1;

  await session.update({
    count: count,
  });

  console.log(session.data);

  return { message: 'Hello, world!' };
}
```