### PR TITLE
feat(h3): add h3 integration

### DIFF
--- a/packages/core/src/Common/App.ts
+++ b/packages/core/src/Common/App.ts
@@ -100,7 +100,11 @@ export class App {
     // listen for incoming requests
     await this.gHttpServer.listen();
 
-    this.gLogger?.info(`\n${colors.green('➜')} App listening on port ${colors.bold(this.fConfig.server?.port?.toString() ?? '3000')}`);
+    this.gLogger?.info(
+      `\n${colors.green('➜')} App listening on port ${colors.bold(
+        this.fConfig.server?.port?.toString() ?? '3000',
+      )}`,
+    );
 
     this.fIsInitialized = true;
   }

--- a/packages/core/src/Common/App.ts
+++ b/packages/core/src/Common/App.ts
@@ -1,10 +1,12 @@
-import { type Container, initializeContainer, Inject } from '@vercube/di';
+import { type Container, initializeContainer, Inject, InjectOptional } from '@vercube/di';
 import { PluginsRegistry } from '../Services/Plugins/PluginsRegistry';
 import type { BasePlugin } from '../Services/Plugins/BasePlugin';
 import { ConfigTypes } from '../Types/ConfigTypes';
 import { HttpServer } from '../Services/HttpServer/HttpServer';
 import { Router } from '../Services/Router/Router';
 import { StaticRequestHandler } from '../Services/Router/StaticRequestHandler';
+import { Logger } from '@vercube/logger';
+import { colors } from '@vercube/logger';
 
 /**
  * Represents the main application class.
@@ -22,6 +24,9 @@ export class App {
 
   @Inject(StaticRequestHandler)
   private gStaticRequestHandler: StaticRequestHandler;
+
+  @InjectOptional(Logger)
+  private gLogger: Logger | null;
 
   /** Holds the initialization status of the application */
   private fIsInitialized: boolean = false;
@@ -95,6 +100,8 @@ export class App {
 
     // listen for incoming requests
     await this.gHttpServer.listen();
+
+    this.gLogger?.info(`\n${colors.green('➜')} App listening on port ${colors.bold(this.fConfig.server?.port?.toString() ?? '3000')}`);
 
     this.fIsInitialized = true;
   }

--- a/packages/core/src/Common/App.ts
+++ b/packages/core/src/Common/App.ts
@@ -5,8 +5,7 @@ import { ConfigTypes } from '../Types/ConfigTypes';
 import { HttpServer } from '../Services/HttpServer/HttpServer';
 import { Router } from '../Services/Router/Router';
 import { StaticRequestHandler } from '../Services/Router/StaticRequestHandler';
-import { Logger } from '@vercube/logger';
-import { colors } from '@vercube/logger';
+import { Logger, colors } from '@vercube/logger';
 
 /**
  * Represents the main application class.

--- a/packages/core/src/Services/HttpServer/HttpServer.ts
+++ b/packages/core/src/Services/HttpServer/HttpServer.ts
@@ -91,7 +91,7 @@ export class HttpServer {
    * @returns {Promise<Response>} The HTTP response
    * @private
    */
-  private async handleRequest(request: Request): Promise<Response> {
+  public async handleRequest(request: Request): Promise<Response> {
     try {
       const route = this.gRouter.resolve({ path: request.url, method: request.method });
 

--- a/packages/devkit/src/Server/DevServer.ts
+++ b/packages/devkit/src/Server/DevServer.ts
@@ -42,7 +42,6 @@ export function createDevServer(app: DevKitTypes.App): DevKitTypes.DevServer {
     reloadPromise = _reload()
       .then(() => {
         consola.success({ tag: 'worker', message: 'Worker reloaded successfully' });
-        consola.log(`\n${colors.green('➜')} App listening on port ${colors.bold(app.config.server?.port ?? 3000)}`);
       })
       .catch((error) => {
         consola.error({ tag: 'worker', message: 'Failed to reload worker', error });

--- a/packages/h3/README.md
+++ b/packages/h3/README.md
@@ -23,7 +23,33 @@
 An ultra-efficient JavaScript server framework that runs anywhere - Node.js, Bun, or Deno - with unmatched flexibility and complete configurability for developers who refuse to sacrifice speed or control.
 
 ## <a name="module">H3 Module</a>
-TODO: describe module
+## <a name="module">H3 Module</a>
+The H3 module provides integration between Vercube applications and the H3 HTTP framework. 
+It allows you to:
+
+- Mount Vercube applications on [H3](https://h3.dev) server
+- Use H3's routing capabilities with Vercube's application logic
+- Integrate Vercube with other H3-based frameworks
+
+### Basic Usage
+
+```ts
+import { createApp } from '@vercube/core';
+import { toH3 } from '@vercube/h3';
+import { H3, serve } from 'h3';
+
+// Create Vercube app
+const app = await createApp();
+
+// Create H3 server
+const h3app = new H3();
+
+// Mount Vercube app at /api path
+h3app.all('/api/**', toH3(app));
+
+// Start the server
+await serve(h3app, { port: 3000 });
+```
 
 
 ## <a name="documentation">📖 Documentation</a>

--- a/packages/h3/README.md
+++ b/packages/h3/README.md
@@ -1,0 +1,30 @@
+<div align="center">
+  <a href="https://vercube.dev/"><img src="https://github.com/OskarLebuda/vue-lazy-hydration/raw/main/.github/assets/logo.png?raw=true" alt="Vite logo" width="200"></a>
+  <br>
+  <br>
+
+  # Vercube
+  
+  Next generation HTTP framework
+  
+  <a href="https://www.npmjs.com/package/@vercube/h3">
+    <img src="https://img.shields.io/npm/v/%40vercube%2Fh3?style=for-the-badge&logo=npm&color=%23767eff" alt="npm"/>
+  </a>
+  <a href="https://www.npmjs.com/package/@vercube/h3">
+    <img src="https://img.shields.io/npm/dm/%40vercube%2Fh3?style=for-the-badge&logo=npm&color=%23767eff" alt="npm"/>
+  </a>
+  <a href="https://github.com/vercube/vercube/blob/main/LICENSE" target="_blank">
+    <img src="https://img.shields.io/npm/l/%40vercube%2Fdi?style=for-the-badge&color=%23767eff" alt="License"/>
+  </a>
+  <br/>
+  <br/>
+</div>
+
+An ultra-efficient JavaScript server framework that runs anywhere - Node.js, Bun, or Deno - with unmatched flexibility and complete configurability for developers who refuse to sacrifice speed or control.
+
+## <a name="module">H3 Module</a>
+TODO: describe module
+
+
+## <a name="documentation">📖 Documentation</a>
+Comprehensive documentation is available at [vercube.dev](https://vercube.dev). There you'll find detailed module descriptions, project information, guides, and everything else you need to know about Vercube.

--- a/packages/h3/README.md
+++ b/packages/h3/README.md
@@ -23,7 +23,6 @@
 An ultra-efficient JavaScript server framework that runs anywhere - Node.js, Bun, or Deno - with unmatched flexibility and complete configurability for developers who refuse to sacrifice speed or control.
 
 ## <a name="module">H3 Module</a>
-## <a name="module">H3 Module</a>
 The H3 module provides integration between Vercube applications and the H3 HTTP framework. 
 It allows you to:
 

--- a/packages/h3/package.json
+++ b/packages/h3/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@vercube/h3",
+  "version": "0.0.2-beta.1",
+  "description": "H3  module for Vercube framework",
+  "packageManager": "pnpm@9.10.0",
+  "repository": "@vercube/h3",
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "dependencies": {
+    "@vercube/core": "workspace:*",
+    "h3": "npm:h3-nightly@2x"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/h3/package.json
+++ b/packages/h3/package.json
@@ -3,7 +3,11 @@
   "version": "0.0.2-beta.1",
   "description": "H3  module for Vercube framework",
   "packageManager": "pnpm@9.10.0",
-  "repository": "@vercube/h3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercube/vercube.git",
+    "directory": "packages/h3"
+  },
   "license": "MIT",
   "sideEffects": false,
   "type": "module",

--- a/packages/h3/project.json
+++ b/packages/h3/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "@vercube/h3",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "{projectRoot}/src",
+  "targets": {
+    "build": {
+      "executor": "@vercube/nx:rolldown",
+      "options": {
+      }
+    }
+  }
+}

--- a/packages/h3/src/index.ts
+++ b/packages/h3/src/index.ts
@@ -1,0 +1,32 @@
+import { type App, HttpServer } from '@vercube/core';
+import { type EventHandler, type H3Event } from 'h3';
+
+/**
+ * Converts a Vercube application to an H3 event handler
+ * 
+ * This adapter allows Vercube applications to be integrated with H3 servers by converting
+ * the Vercube request handling pipeline into an H3-compatible event handler.
+ * 
+ * @param {App} app - The Vercube application instance to adapt
+ * @returns {EventHandler} An H3 event handler that processes requests through the Vercube app
+ * 
+ * @example
+ * ```ts
+ * import { createApp } from '@vercube/core'
+ * import { toH3 } from '@vercube/h3'
+ * import { H3 } from 'h3'
+ * 
+ * const h3app = new H3()
+ * const app = await createApp()
+ * 
+ * // Mount Vercube app at /api path
+ * h3app.all('/api/**', toH3(app))
+ * ```
+ */
+
+export function toH3(app: App): EventHandler {
+  return (event: H3Event) => {
+    const server = app.container.get(HttpServer);
+    return server.handleRequest(event.req);
+  };
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -5,7 +5,7 @@ export * from './Common/Logger';
 export * from './Service/BaseLogger';
 
 // Utils
-export { isLogLevelEnabled } from './Utils/Utils';
+export { isLogLevelEnabled, colors } from './Utils/Utils';
 
 // Types
 export * from './Types/LoggerTypes';

--- a/playground/package.json
+++ b/playground/package.json
@@ -20,6 +20,8 @@
     "@vercube/di": "workspace:*",
     "@vercube/logger": "workspace:*",
     "@vercube/storage": "workspace:*",
+    "@vercube/h3": "workspace:*",
+    "h3": "npm:h3-nightly@2x",
     "tslib": "2.8.1",
     "zod": "3.24.3"
   }

--- a/playground/src/index.ts
+++ b/playground/src/index.ts
@@ -1,15 +1,22 @@
 import { createApp } from '@vercube/core';
+import { toH3 } from '@vercube/h3';
 import { useContainer } from './Boot/Container';
-import { CustomPlugin } from './Plugins/CustomPlugin';
+import { H3, serve } from 'h3';
+
+const h3app = new H3();
 
 async function main() {
   const app = await createApp();
 
   app.container.expand(useContainer);
 
-  app.registerPlugin(CustomPlugin, { foo: 'bar' });
+  h3app.all('/api/**', toH3(app));
 
-  await app.listen();
+  await serve(h3app, { port: 3000 })
+    .ready()
+    .then((server) => {
+      console.log(`🚀 Server ready at ${server.url}`);
+    });
 }
 
 await main();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,15 @@ importers:
 
   packages/di: {}
 
+  packages/h3:
+    dependencies:
+      '@vercube/core':
+        specifier: workspace:*
+        version: link:../core
+      h3:
+        specifier: npm:h3-nightly@2x
+        version: h3-nightly@2.0.0-20250417-222045-ac609aa
+
   packages/logger:
     dependencies:
       '@vercube/di':
@@ -239,12 +248,21 @@ importers:
       '@vercube/di':
         specifier: workspace:*
         version: link:../packages/di
+      '@vercube/h3':
+        specifier: workspace:*
+        version: link:../packages/h3
       '@vercube/logger':
         specifier: workspace:*
         version: link:../packages/logger
       '@vercube/storage':
         specifier: workspace:*
         version: link:../packages/storage
+      h3:
+        specifier: npm:h3-nightly@2x
+        version: h3-nightly@2.0.0-20250417-222045-ac609aa
+      srvx:
+        specifier: 0.4.0
+        version: 0.4.0
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -4015,6 +4033,15 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  h3-nightly@2.0.0-20250417-222045-ac609aa:
+    resolution: {integrity: sha512-EryLx6x5mGja0RqTHpdu+ItdVyB+i78AeRqac7DLeYbHW7vSEpvKwTBgTom3fMXSBwqR1OHuAF6IFqzFm9RpIw==}
+    engines: {node: '>=20.11.1'}
+    peerDependencies:
+      crossws: ^0.2.4
+    peerDependenciesMeta:
+      crossws:
+        optional: true
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
@@ -9854,6 +9881,12 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  h3-nightly@2.0.0-20250417-222045-ac609aa:
+    dependencies:
+      cookie-es: 2.0.0
+      rou3: 0.6.0
+      srvx: 0.4.0
 
   hachure-fill@0.5.2: {}
 


### PR DESCRIPTION
Add [H3@2](https://github.com/h3js/h3) integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `@vercube/h3` package, enabling seamless integration of Vercube applications with the H3 framework.
	- Added a utility function to adapt Vercube apps as H3 event handlers for flexible deployment options.
- **Improvements**
	- Enhanced logging with optional logger support, providing clearer startup messages.
	- Updated logger utilities to include color formatting.
	- Made HTTP server request handling method publicly accessible for extended use.
- **Chores**
	- Added documentation and configuration files for the new package.
	- Updated dependencies and server setup in the playground for H3 compatibility.
- **Style**
	- Removed redundant console log messages for cleaner output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->