### PR TITLE
feat(options): add preflight handling and tests

### DIFF
--- a/packages/core/src/Services/HttpServer/HttpServer.ts
+++ b/packages/core/src/Services/HttpServer/HttpServer.ts
@@ -120,6 +120,11 @@ export class HttpServer {
         method: request.method,
       });
 
+      // handle preflight request
+      if (!route && request.method === 'OPTIONS') {
+        return this.gRequestHandler.handlePreflight(request);
+      }
+
       // if no route is found, try to serve static file
       if (!route) {
         const response = await this.gStaticRequestHandler.handleRequest(request);


### PR DESCRIPTION
Added support for handling OPTIONS preflight requests.  
If an OPTIONS request is not explicitly registered as a route, it now triggers global middleware (e.g., for CORS handling).  
If it is registered, the request is handled normally.  

Also added unit tests.