### PR TITLE
feat(query-params): casting query params to appropriate type

### DIFF
--- a/packages/core/src/Resolvers/Query.ts
+++ b/packages/core/src/Resolvers/Query.ts
@@ -1,14 +1,17 @@
 import type { RouterTypes } from '../Types/RouterTypes';
 
+type QueryParamValue = string | number | boolean | null;
+
 /**
  * Resolves a single query parameter from the URL of a router event
  * @param name - The name of the query parameter to resolve
  * @param event - The router event containing the request URL
  * @returns The value of the query parameter if found, null otherwise
  */
-export function resolveQueryParam(name: string, event: RouterTypes.RouterEvent): string | null {
+export function resolveQueryParam(name: string, event: RouterTypes.RouterEvent): QueryParamValue {
   const url = new URL(event.request.url);
-  return url.searchParams.get(name);
+  const value = url.searchParams.get(name);
+  return castValue(value);
 }
 
 /**
@@ -16,13 +19,34 @@ export function resolveQueryParam(name: string, event: RouterTypes.RouterEvent):
  * @param event - The router event containing the request URL
  * @returns An object containing all query parameters as key-value pairs
  */
-export function resolveQueryParams(event: RouterTypes.RouterEvent): Record<string, string> {
+export function resolveQueryParams(event: RouterTypes.RouterEvent): Record<string, QueryParamValue> {
   const url = new URL(event.request.url);
-  const params: Record<string, string> = {};
+  const params: Record<string, QueryParamValue> = {};
 
   for (const [key, value] of url.searchParams) {
-    params[key] = value;
+    params[key] = castValue(value);
   }
 
   return params;
+}
+
+/**
+ * Function to cast a string value to its appropriate type (string, number, or boolean)
+ * @param value - The string value to be cast
+ * @returns The casted value as string, number, or boolean
+ */
+function castValue(value: string | null): QueryParamValue {
+  if (value === null || value === '') {
+    return value;
+  }
+
+  if (!Number.isNaN(Number(value))) {
+    return Number(value);
+  }
+
+  if (value === 'true' || value === 'false') {
+    return value === 'true';
+  }
+
+  return value;
 }

--- a/packages/core/test/Resolvers/Query.test.ts
+++ b/packages/core/test/Resolvers/Query.test.ts
@@ -79,14 +79,14 @@ describe('Query Resolvers', () => {
       const event = createMockEvent('http://localhost/test?id=123&count=456');
       const result = resolveQueryParam('id', event);
 
-      expect(result).toBe('123');
+      expect(result).toBe(123);
     });
 
     it('should handle boolean-like query parameters', () => {
       const event = createMockEvent('http://localhost/test?active=true&enabled=false');
       const result = resolveQueryParam('active', event);
 
-      expect(result).toBe('true');
+      expect(result).toBe(true);
     });
 
     it('should handle complex query parameter values', () => {
@@ -104,8 +104,8 @@ describe('Query Resolvers', () => {
 
       expect(result).toEqual({
         name: 'John',
-        age: '30',
-        active: 'true',
+        age: 30,
+        active: true,
       });
     });
 
@@ -148,7 +148,7 @@ describe('Query Resolvers', () => {
 
       expect(result).toEqual({
         name: '',
-        age: '30',
+        age: 30,
         empty: '',
       });
     });
@@ -168,9 +168,9 @@ describe('Query Resolvers', () => {
       const result = resolveQueryParams(event);
 
       expect(result).toEqual({
-        id: '123',
-        count: '456',
-        price: '99.99',
+        id: 123,
+        count: 456,
+        price: 99.99,
       });
     });
 
@@ -179,9 +179,9 @@ describe('Query Resolvers', () => {
       const result = resolveQueryParams(event);
 
       expect(result).toEqual({
-        active: 'true',
-        enabled: 'false',
-        visible: '1',
+        active: true,
+        enabled: false,
+        visible: 1,
       });
     });
 


### PR DESCRIPTION
Casted query params to the correct types before validation.
Previously, Zod validation always failed unless using z.string(), since query params come in as strings. Now params are properly converted to their intended types before being passed to the schema.