### PR TITLE
fix(error-handling): wrap handleError in Promise.resolve to stop unau…

### DIFF
--- a/packages/core/src/Services/Router/RequestHandler.ts
+++ b/packages/core/src/Services/Router/RequestHandler.ts
@@ -140,11 +140,8 @@ export class RequestHandler {
             fakeResponse = this.processOverrideResponse(hookResponse!, fakeResponse);
           }
         } catch (error) {
-          const internalError = this.gContainer.get(ErrorHandlerProvider).handleError(error);
-
-          if (internalError instanceof Response) {
-            return internalError;
-          }
+          const internalError = await Promise.resolve(this.gContainer.get(ErrorHandlerProvider).handleError(error));
+          return internalError;
         }
       }
 
@@ -213,11 +210,8 @@ export class RequestHandler {
               return hookResponse;
             }
           } catch (error) {
-            const internalError = this.gContainer.get(ErrorHandlerProvider).handleError(error);
-
-            if (internalError instanceof Response) {
-              return internalError;
-            }
+            const internalError = await Promise.resolve(this.gContainer.get(ErrorHandlerProvider).handleError(error));
+            return internalError;
           }
         }
       }
@@ -248,11 +242,8 @@ export class RequestHandler {
               fakeResponse = this.processOverrideResponse(hookResponse!, fakeResponse);
             }
           } catch (error) {
-            const internalError = this.gContainer.get(ErrorHandlerProvider).handleError(error);
-
-            if (internalError instanceof Response) {
-              return internalError;
-            }
+            const internalError = await Promise.resolve(this.gContainer.get(ErrorHandlerProvider).handleError(error));
+            return internalError;
           }
         }
       }


### PR DESCRIPTION
I updated the error handling logic so that handleError() results are always treated consistently as a Promise<Response>.
Since handleError can return either a synchronous Response or an asynchronous Promise<Response>, I wrapped the call in Promise.resolve(...).

Previously, when handleError was implemented asynchronously, there was a risk that a request without proper authorization could still reach the controller action before the error response was returned.
With this change, the flow is guaranteed to await the error handling result before proceeding, ensuring correct authorization handling.