### PR TITLE
fix: stream response

### DIFF
--- a/packages/core/src/Services/Router/RequestHandler.ts
+++ b/packages/core/src/Services/Router/RequestHandler.ts
@@ -248,7 +248,12 @@ export class RequestHandler {
         }
       }
 
-      // 6. Set response
+      // 6. If handlerResponse is already instance if Response, return it
+      if (handlerResponse instanceof Response) {
+        return handlerResponse;
+      }
+
+      // 7. Otherwise prepare new response
       const body = fakeResponse?.body ?? JSON.stringify(handlerResponse);
 
       const response = new Response(body, {

--- a/packages/core/test/Services/RequestHandler.test.ts
+++ b/packages/core/test/Services/RequestHandler.test.ts
@@ -610,6 +610,50 @@ describe('RequestHandler', () => {
       expect(result.status).toBe(200);
       expect(await result.text()).toBe('"Default response"');
     });
+
+    it('should return handlerResponse directly when it is already a Response instance', async () => {
+      const customResponse = new Response('Custom Response', {
+        status: 201,
+        statusText: 'Created',
+        headers: { 'X-Custom-Header': 'test-value' },
+      });
+
+      const mockInstanceWithResponseReturn = {
+        testMethod: vi.fn().mockReturnValue(customResponse),
+      };
+
+      mockRoute.data.instance = mockInstanceWithResponseReturn;
+
+      const result = await requestHandler.handleRequest(mockRequest, mockRoute);
+
+      expect(result).toBe(customResponse);
+      expect(result.status).toBe(201);
+      expect(result.statusText).toBe('Created');
+      expect(result.headers.get('X-Custom-Header')).toBe('test-value');
+      expect(await result.text()).toBe('Custom Response');
+    });
+
+    it('should return async handlerResponse directly when it is already a Response instance', async () => {
+      const customResponse = new Response('Async Custom Response', {
+        status: 202,
+        statusText: 'Accepted',
+        headers: { 'X-Async-Header': 'async-value' },
+      });
+
+      const mockInstanceWithAsyncResponseReturn = {
+        testMethod: vi.fn().mockResolvedValue(customResponse),
+      };
+
+      mockRoute.data.instance = mockInstanceWithAsyncResponseReturn;
+
+      const result = await requestHandler.handleRequest(mockRequest, mockRoute);
+
+      expect(result).toBe(customResponse);
+      expect(result.status).toBe(202);
+      expect(result.statusText).toBe('Accepted');
+      expect(result.headers.get('X-Async-Header')).toBe('async-value');
+      expect(await result.text()).toBe('Async Custom Response');
+    });
   });
 
   describe('processOverrideResponse', () => {


### PR DESCRIPTION
This pull request improves the `RequestHandler` logic to correctly handle cases where the route handler returns a `Response` object directly, ensuring it’s returned without modification. It also adds comprehensive tests to verify both synchronous and asynchronous scenarios where a `Response` instance is returned.

This behavior is critical when working with libraries such as `@ai-sdk`, since the entire `Response` object must be passed to the client without any alteration.
