### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "enabledManagers": ["npm"],
   "rangeStrategy": "replace",
   "timezone": "Europe/Warsaw",


### PR DESCRIPTION
## Summary
- migrate Renovate's deprecated `config:base` preset to `config:recommended`
- preserve the existing managers, package rules, scheduling, and dashboard settings

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`