### PR TITLE
feat(cache): add cache layer

### DIFF
--- a/docs/3.modules/9.cache/.navigation.yml
+++ b/docs/3.modules/9.cache/.navigation.yml
@@ -1,0 +1,3 @@
+title: Cache
+icon: false
+defaultOpen: false

--- a/docs/3.modules/9.cache/0.overview.md
+++ b/docs/3.modules/9.cache/0.overview.md
@@ -1,0 +1,188 @@
+---
+title: Overview
+description: Decorator driven caching for Vercube applications, backed by the Storage module
+---
+
+The Cache module turns any method into a cached one with a single decorator. It handles time-based expiration, stale-while-revalidate refreshes, concurrent call deduplication and automatic invalidation when your code changes - while keeping every entry inside a regular [Storage](/docs/modules/storage) instance, so memory, S3 or any other driver backs your cache without a line of glue code.
+
+## Installation
+
+::code-group
+  ```bash [pnpm]
+  $ pnpm add @vercube/cache @vercube/storage
+  ```
+  ```bash [npm]
+  $ npm install @vercube/cache @vercube/storage
+  ```
+  ```bash [bun]
+  $ bun install @vercube/cache @vercube/storage
+  ```
+::
+
+## Quick Start
+
+::steps
+### Register the cache in your container
+
+The Cache module stores everything through the Storage module, so bind both. Mounting a storage named `cache` keeps cached entries away from the rest of your data.
+
+```ts [src/container.ts]
+import { Container } from '@vercube/di';
+import { CacheManager } from '@vercube/cache';
+import { StorageManager } from '@vercube/storage';
+import { MemoryStorage } from '@vercube/storage/drivers/MemoryStorage';
+
+export async function setupContainer(container: Container): Promise<void> {
+  container.bind(StorageManager);
+  container.bind(CacheManager);
+
+  const storageManager = container.get(StorageManager);
+  await storageManager.mount({ name: 'cache', storage: MemoryStorage });
+
+  // application wide defaults, every cached function can override them
+  container.get(CacheManager).configure({
+    storage: 'cache',
+    maxAge: 60,
+  });
+}
+```
+
+### Cache a method
+
+Decorate any method of a class registered in the container. The cache key is derived from the method's arguments, so every distinct set of arguments gets its own entry.
+
+```ts [src/services/UsersService.ts]
+import { Cache } from '@vercube/cache';
+
+export class UsersService {
+  @Cache({ maxAge: 300 })
+  public async getUser(id: string): Promise<User> {
+    return this.database.findUser(id);
+  }
+}
+```
+
+That is the whole setup. The first call hits the database, every call within the next 5 minutes is served from the storage, and simultaneous calls for the same `id` share a single database round trip.
+
+### Invalidate when data changes
+
+Every decorated method gains `invalidate()`, `expire()` and `resolveKeys()` helpers, keyed exactly like the cached calls - you never rebuild a cache key by hand.
+
+```ts [src/services/UsersService.ts]
+import { Cache } from '@vercube/cache';
+import type { CacheTypes } from '@vercube/cache';
+
+export class UsersService {
+  @Cache({ maxAge: 300 })
+  public async getUser(id: string): Promise<User> {
+    return this.database.findUser(id);
+  }
+
+  public async updateUser(id: string, patch: Partial<User>): Promise<User> {
+    const user = await this.database.updateUser(id, patch);
+
+    // drop the cached entry for this user only
+    await (this.getUser as CacheTypes.CachedMethod<[string], User>).invalidate(id);
+
+    return user;
+  }
+}
+```
+::
+
+## How it works
+
+Cached entries are plain objects written into a mounted storage. Each cache key carries the storage it belongs to:
+
+```
+/cache/<storage>:<group>:<name>:<argument-hash>.json   # a named storage
+/cache:<group>:<name>:<argument-hash>.json             # the default storage
+```
+
+The Cache module resolves that prefix back to a mounted storage on every read and write, which means a single application can cache different things in different places - hot data in memory, shared data in a distributed storage - and inspect any of it through the regular `StorageManager` API.
+
+If a cached function points at a storage nobody mounted, an in-memory one is mounted under that name on first use and a warning is logged. Caching therefore works with zero configuration, and mounting the name yourself is what swaps the backend for a real one.
+
+## Freshness
+
+| Option | What it does |
+| --- | --- |
+| `maxAge` | Seconds an entry stays fresh. Defaults to `1`. |
+| `swr` | Serve a stale entry immediately and refresh it in the background. |
+| `staleMaxAge` | How long a stale entry may still be served while revalidating. |
+| `getMaxAge` | Derive the lifetime from the resolved value, e.g. an OAuth token's `expires_in`. |
+
+```ts
+export class RatesService {
+  // serve instantly for a minute, then keep serving the old value for up to
+  // five more minutes while a fresh one is fetched in the background
+  @Cache({ maxAge: 60, swr: true, staleMaxAge: 300 })
+  public async getRates(currency: string): Promise<Rates> {
+    return this.http.get(`/rates/${currency}`);
+  }
+}
+```
+
+## Cache keys
+
+By default the key is a hash of the method's arguments. That is the right behaviour for plain values (strings, numbers, POJOs), but arguments that are not stable to hash - a `Request`, a stream, a class instance carrying a connection - should be projected into an explicit key:
+
+```ts
+export class ReportsController {
+  @Cache({
+    maxAge: 300,
+    getKey: (range: DateRange) => `${range.from}:${range.to}`,
+  })
+  public async report(range: DateRange, trace: TraceContext): Promise<Report> {
+    return this.reports.build(range);
+  }
+}
+```
+
+Entries also carry an integrity hash derived from the method body and its cache options. Changing either drops the old entries automatically, so a deploy never serves results produced by code that no longer exists.
+
+## Caching controller responses
+
+A controller action is just a method, and by the time it runs its arguments are already the resolved route parameters. Decorating it caches the response keyed by those parameters:
+
+```ts [src/controllers/ProductsController.ts]
+import { Cache } from '@vercube/cache';
+import { Controller, Get, Param } from '@vercube/core';
+
+@Controller('/products')
+export class ProductsController {
+  @Get('/:id')
+  @Cache({ maxAge: 120, swr: true, staleMaxAge: 600 })
+  public async getProduct(@Param('id') id: string): Promise<Product> {
+    return this.products.find(id);
+  }
+}
+```
+
+::warning
+Only cache actions whose response depends purely on the arguments the method receives. An action that reads the authenticated user, a header or a cookie without taking it as an argument would serve one user's response to another - pass those values in as parameters so they become part of the key, or leave the action uncached.
+::
+
+## Multi-tier caching
+
+Passing several storages reads them in order and writes to all of them, which gives a fast local tier in front of a shared one:
+
+```ts
+export class CatalogService {
+  @Cache({ maxAge: 300, storage: ['memory', 'shared'] })
+  public async getCatalog(): Promise<Catalog> {
+    return this.database.loadCatalog();
+  }
+}
+```
+
+A read tries `memory` first and falls through to `shared`. A resolved value is written to every tier.
+
+## Caveats
+
+- `@Cache()` works on classes registered in the container. Instances created with `new` by hand are not decorated.
+- Cached entries are written to storage as-is, so the returned value must survive whatever serialization the driver applies. Use `serialize` / `transform` for values that do not, such as streams or class instances.
+- Expiration is enforced by the cache itself, so a driver that ignores the `ttl` hint (the built-in `MemoryStorage` does) still serves correct results - it just never evicts expired entries on its own.
+- **Entries are shared between instances of the same class.** The key is built from the class name, the method name and the arguments - never from instance identity. If you register the same class twice with different constructor state (say two API clients pointing at different hosts), give each one an explicit `name` so they do not read each other's entries.
+- **Minified builds mangle class names.** Since the default `name` is `ClassName.methodName`, two different classes can collapse onto the same name after minification and fight over one key. The integrity hash keeps you from being served the wrong data, but the hit rate collapses. Pass an explicit `name` for anything shipped minified.
+- **The caching engine keeps one storage per process.** Every cached function in the process routes through the `CacheManager` that initialized last, regardless of which container created it. That is invisible in a normal single-app process, but two apps sharing one process (or an app plus tests) will read and write through each other's storages. A warning is logged when a second `CacheManager` takes over.

--- a/docs/3.modules/9.cache/1.api.md
+++ b/docs/3.modules/9.cache/1.api.md
@@ -1,0 +1,277 @@
+---
+title: API
+description: Complete API reference for Cache module
+---
+
+This page provides a complete API reference for all decorators, classes, and types in the `@vercube/cache` package.
+
+## `@Cache()` (Decorator)
+
+Replaces the decorated method with a cached version of itself. The cache key is derived from the method's arguments, concurrent calls for the same key are coalesced into a single execution, and entries are dropped automatically when the method body or its options change.
+
+### Signature
+
+```ts
+function Cache(options?: CacheTypes.DecoratorOptions): Function
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `options` | `CacheTypes.DecoratorOptions` | No | Cache options for this method. See [Options](#cachetypesoptions-interface). |
+
+When `name` is not given it defaults to `ClassName.methodName`, so two classes declaring the same method name never share entries.
+
+**Example:**
+
+```ts
+import { Cache } from '@vercube/cache';
+
+export class UsersService {
+  @Cache({ maxAge: 300, swr: true, staleMaxAge: 900, storage: 'cache' })
+  public async getUser(id: string): Promise<User> {
+    return this.database.findUser(id);
+  }
+}
+```
+
+### Helpers on the decorated method
+
+The decorated method exposes three helpers that resolve exactly the keys the cached calls use.
+
+```ts
+type CachedMethod<ArgsT extends unknown[], T> = {
+  (...args: ArgsT): Promise<T>;
+  resolveKeys(...args: ArgsT): Promise<string[]>;
+  invalidate(...args: ArgsT): Promise<void>;
+  expire(...args: ArgsT): Promise<void>;
+};
+```
+
+| Helper | Description |
+|--------|-------------|
+| `resolveKeys()` | Returns every storage key (one per storage tier) the given arguments cache under. |
+| `invalidate()` | Removes the cached entries for the given arguments. The next call resolves again. |
+| `expire()` | Marks the entries stale without removing them. With `swr` the stale value is still served while the next access refreshes it. |
+
+**Example:**
+
+```ts
+import type { CacheTypes } from '@vercube/cache';
+
+const getUser = usersService.getUser as CacheTypes.CachedMethod<[string], User>;
+
+await getUser.resolveKeys('123'); // ['/cache:functions:UsersService.getUser:....json']
+await getUser.invalidate('123');
+await getUser.expire('123');
+```
+
+::note
+The cast is only needed to make the helpers visible to TypeScript - decorators cannot widen a method's declared type. At runtime the helpers are always there.
+::
+
+## CacheManager (Class)
+
+The central service of the module. It wires the caching engine to the storages mounted in `@vercube/storage`, holds the application wide defaults, and exposes the imperative API used both directly and by the `@Cache()` decorator.
+
+### Signature
+
+```ts
+class CacheManager {
+  public get adapter(): CacheStorageAdapter | null;
+  public get defaults(): CacheTypes.Defaults;
+  public configure(defaults: CacheTypes.Defaults): void;
+  public cached<T, ArgsT>(fn: (...args: ArgsT) => T | Promise<T>, options?: CacheTypes.Options<T, ArgsT>): CacheTypes.CachedFunction<T, ArgsT>;
+  public invalidate<ArgsT>(options: CacheTypes.Options<any, ArgsT>, ...args: ArgsT): Promise<void>;
+  public expire<ArgsT>(options: CacheTypes.Options<any, ArgsT>, ...args: ArgsT): Promise<void>;
+  public resolveKeys<ArgsT>(options: CacheTypes.Options<any, ArgsT>, ...args: ArgsT): Promise<string[]>;
+}
+```
+
+### Methods
+
+#### `configure()`
+
+Sets the application wide cache defaults. Options passed per cached function always win. Repeated calls merge into the existing defaults.
+
+```ts
+public configure(defaults: CacheTypes.Defaults): void
+```
+
+**Example:**
+
+```ts
+container.get(CacheManager).configure({
+  storage: 'cache',
+  maxAge: 60,
+  swr: true,
+  staleMaxAge: 600,
+  onError: (error) => logger.error('Cache failure', error),
+});
+```
+
+#### `cached()`
+
+Wraps a function with caching. Use it for functions that are not class methods, or when the options are only known at runtime.
+
+```ts
+public cached<T, ArgsT extends unknown[]>(
+  fn: (...args: ArgsT) => T | Promise<T>,
+  options?: CacheTypes.Options<T, ArgsT>,
+): CacheTypes.CachedFunction<T, ArgsT>
+```
+
+**Returns:** the cached function, carrying the same `resolveKeys()`, `invalidate()` and `expire()` helpers as a decorated method.
+
+**Throws:** `CacheError` when `fn` is not a function.
+
+**Example:**
+
+```ts
+const getRates = cacheManager.cached(
+  (currency: string) => http.get(`/rates/${currency}`),
+  { name: 'getRates', maxAge: 60, swr: true, staleMaxAge: 300 },
+);
+
+await getRates('EUR');
+await getRates.invalidate('EUR');
+```
+
+#### `invalidate()` / `expire()` / `resolveKeys()`
+
+Act on entries without holding a reference to the cached function. Pass the same options (`name`, `group`, `storage`, `getKey`) the entry was cached with, so the very same keys are resolved.
+
+```ts
+public invalidate<ArgsT>(options: CacheTypes.Options<any, ArgsT>, ...args: ArgsT): Promise<void>
+public expire<ArgsT>(options: CacheTypes.Options<any, ArgsT>, ...args: ArgsT): Promise<void>
+public resolveKeys<ArgsT>(options: CacheTypes.Options<any, ArgsT>, ...args: ArgsT): Promise<string[]>
+```
+
+**Example:**
+
+```ts
+// drop what UsersService.getUser cached for user 123, from anywhere in the app
+await cacheManager.invalidate({ name: 'UsersService.getUser', storage: 'cache' }, '123');
+```
+
+## CacheTypes.Options (Interface)
+
+Options accepted by `@Cache()` and `CacheManager.cached()`.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `name` | `string` | `ClassName.methodName` | Name used as part of the cache key. |
+| `group` | `string` | `'functions'` | Key group prefix, useful for grouping related entries. |
+| `storage` | `string \| string[]` | `'default'` | Mounted storage(s) backing the entries. An array reads in order and writes to all; it must not be empty, and a name must not contain a colon. |
+| `maxAge` | `number` | `1` | Seconds an entry stays fresh. |
+| `swr` | `boolean` | `false` | Serve a stale entry while refreshing it in the background. |
+| `staleMaxAge` | `number` | - | Seconds a stale entry may still be served while revalidating. `0` never serves stale. |
+| `getKey` | `(...args) => string \| Promise<string>` | hash of the arguments | Derives the key segment from the arguments. |
+| `getMaxAge` | `(entry) => number \| { maxAge?, staleMaxAge? }` | - | Derives the lifetime from the resolved value. |
+| `validate` | `(entry, ctx) => boolean \| Promise<boolean>` | value is defined | Return `false` to treat an entry as invalid and re-resolve. |
+| `shouldBypassCache` | `(...args) => boolean \| Promise<boolean>` | - | Return `true` to skip the cache entirely for this call. |
+| `shouldInvalidateCache` | `(...args) => boolean \| Promise<boolean>` | - | Return `true` to drop the entry and re-resolve. |
+| `serialize` | `(entry, ctx) => any` | - | Convert the resolved value into a storable shape. Runs once per resolution. |
+| `transform` | `(entry, ...args) => any` | - | Rebuild the usable value when an entry is read back. Also receives `entry.status`. |
+| `integrity` | `unknown` | hash of the method and its options | Overrides the value that invalidates entries when the code changes. |
+| `onError` | `(error: unknown) => void` | logs to console | Called for every cache related error (read, write, background refresh). |
+
+### `entry.status`
+
+Inside `transform` the entry carries how the value was served on that call:
+
+| Status | Meaning |
+|--------|---------|
+| `hit` | A fresh cached value was returned without re-resolving. |
+| `stale` | A stale value was served while a background refresh runs. |
+| `revalidated` | A prior value existed but was expired, so it was re-resolved before returning. |
+| `miss` | The value was resolved fresh on this call. |
+
+```ts
+@Cache({
+  maxAge: 60,
+  swr: true,
+  staleMaxAge: 300,
+  transform: (entry) => {
+    metrics.increment(`cache.${entry.status}`);
+    return entry.value;
+  },
+})
+public async getRates(currency: string): Promise<Rates> { /* ... */ }
+```
+
+## CacheTypes.Defaults (Interface)
+
+Application wide defaults passed to `CacheManager.configure()`. Every field is optional and is overridden by per-function options.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `maxAge` | `number` | Default freshness window in seconds. |
+| `swr` | `boolean` | Default stale-while-revalidate behaviour. |
+| `staleMaxAge` | `number` | Default stale window in seconds. |
+| `group` | `string` | Default key group prefix. |
+| `storage` | `string \| string[]` | Default storage(s) to keep entries in. |
+| `onError` | `(error: unknown) => void` | Default cache error handler. |
+
+## CacheStorageAdapter (Class)
+
+Bridges the caching engine onto the Vercube `StorageManager`. You rarely touch it directly - `CacheManager` installs it during initialization - but it defines how cache keys map onto storages.
+
+### Signature
+
+```ts
+class CacheStorageAdapter {
+  public get<T>(key: string): Promise<T | null>;
+  public set<T>(key: string, value: T, opts?: { ttl?: number }): Promise<void>;
+}
+```
+
+Writing `null` deletes the entry, mirroring how the caching engine signals invalidation.
+
+### Key helpers
+
+```ts
+const CACHE_BASE_PREFIX = '/cache';
+
+function cacheBaseForStorage(storage?: string): string;
+function storageNameFromCacheKey(key: string): string;
+```
+
+| Function | Description |
+|----------|-------------|
+| `cacheBaseForStorage()` | Builds the key base for a mounted storage: `'redis'` becomes `/cache/redis`, the default storage stays `/cache`. |
+| `storageNameFromCacheKey()` | Reads the storage name back out of a full cache key. |
+
+A complete key looks like:
+
+```
+/cache/redis:functions:UsersService.getUser:9f2a1c....json
+└─ base ──┘ └─ group ┘ └────── name ──────┘ └─ arg hash ─┘
+```
+
+::note
+When a cached function points at a storage that has not been mounted, the adapter mounts a `MemoryStorage` under that name on first use and logs a warning. Mounting the name yourself - before or after - is what swaps the backend for a real one.
+::
+
+## CacheError (Class)
+
+Thrown for cache configuration and wiring failures: decorating a non-method, using the cache without a `StorageManager` bound, passing an empty `storage` list, or a storage name containing a colon (which would break key routing).
+
+### Signature
+
+```ts
+class CacheError extends Error {
+  public readonly operation: string;
+  public readonly cause?: Error;
+  public readonly metadata?: Record<string, unknown>;
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `operation` | `string` | The cache operation that failed. |
+| `cause` | `Error` | The underlying error, when there is one. |
+| `metadata` | `Record<string, unknown>` | Non-sensitive context about the failure. |
+
+Storage failures that happen while serving a cached call are **not** thrown - they are routed to the `onError` option so a failing cache never takes the request down. Failures during an explicit `invalidate()` or `expire()` do propagate, since you asked for that write to happen.

--- a/examples/vite/src/server/Boot/Setup.ts
+++ b/examples/vite/src/server/Boot/Setup.ts
@@ -2,7 +2,7 @@ import { WebsocketPlugin } from '@vercube/ws';
 import type { App } from '@vercube/core';
 
 /**
- * App setup hook. Runs before the app initializes — the place to register
+ * App setup hook. Runs before the app initializes - the place to register
  * plugins that auto-discovery cannot infer.
  */
 export default async function setup(app: App): Promise<void> {

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -1,0 +1,54 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/vercube/vercube/refs/heads/main/.github/assets/cover.png" width="100%" alt="Vercube - Unleash your server development." />
+  <br>
+  <br>
+
+# @vercube/cache
+
+### Decorator driven caching for Vercube apps
+
+[![Ask DeepWiki](<https://img.shields.io/badge/ask-deepwiki-%20blue?style=for-the-badge&logo=bookstack&logoColor=rgba(255%2C%20255%2C%20255%2C%200.6)&labelColor=%23000&color=%232f2f2f>)](https://deepwiki.com/vercube/vercube)
+![NPM Version](<https://img.shields.io/npm/v/%40vercube%2Fcache?style=for-the-badge&logo=npm&logoColor=rgba(255%2C%20255%2C%20255%2C%200.6)&labelColor=%23000&color=%232e2e2e&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40vercube%2Fcache>)
+![GitHub License](<https://img.shields.io/github/license/vercube/vercube?style=for-the-badge&logo=gitbook&logoColor=rgba(255%2C%20255%2C%20255%2C%200.6)&labelColor=%23000&color=%232f2f2f>)
+![Codecov](<https://img.shields.io/codecov/c/github/vercube/vercube?style=for-the-badge&logo=vitest&logoColor=rgba(255%2C%20255%2C%20255%2C%200.6)&labelColor=%23000&color=%232f2f2f>)
+
+**One decorator turns any method into a cached one - with TTL, stale-while-revalidate, call deduplication and precise invalidation. Every entry lives in a regular Vercube storage.**
+
+[Website](https://vercube.dev) • [Documentation](https://vercube.dev/docs/getting-started)
+
+</div>
+
+## ✨ Features
+
+- **`@Cache()` decorator** - cache any method, keyed by its arguments
+- **Backed by `@vercube/storage`** - memory, S3 or your own driver, no glue code
+- **Stale-while-revalidate** - serve instantly, refresh in the background
+- **Call deduplication** - concurrent calls for the same key share one execution
+- **Precise invalidation** - `invalidate()` and `expire()` right on the decorated method
+- **Self-invalidating** - entries are dropped when the method body or its options change
+- **Multi-tier** - read through a fast local storage into a shared one
+
+## 📦 Installation
+
+```bash
+pnpm add @vercube/cache @vercube/storage
+```
+
+## 📖 Usage
+
+```ts
+import { Cache } from '@vercube/cache';
+
+export class UsersService {
+  @Cache({ maxAge: 300, swr: true, staleMaxAge: 900 })
+  public async getUser(id: string): Promise<User> {
+    return this.database.findUser(id);
+  }
+}
+```
+
+Check out the full [documentation](https://vercube.dev/docs/modules/cache/overview)
+
+## 📜 License
+
+[MIT](https://github.com/vercube/vercube/blob/main/LICENSE)

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@vercube/cache",
+  "version": "1.1.7",
+  "description": "Cache module for Vercube framework",
+  "packageManager": "pnpm@11.17.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercube/vercube.git",
+    "directory": "packages/cache"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": "./dist/index.mjs",
+    "./package.json": "./package.json"
+  },
+  "types": "./dist/index.d.mts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsdown --config ../../tsdown.config.ts --config-loader=unrun"
+  },
+  "devDependencies": {
+    "@vercube/core": "workspace:*"
+  },
+  "dependencies": {
+    "@vercube/di": "workspace:*",
+    "@vercube/logger": "workspace:*",
+    "@vercube/storage": "workspace:*",
+    "ocache": "catalog:",
+    "ohash": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cache/src/Decorators/Cache.ts
+++ b/packages/cache/src/Decorators/Cache.ts
@@ -1,0 +1,133 @@
+import { BaseDecorator, createDecorator, Inject } from '@vercube/di';
+import { hash } from 'ohash';
+import { CacheError } from '../Errors/CacheError';
+import { CacheManager } from '../Services/CacheManager';
+import type { CacheTypes } from '../Types/CacheTypes';
+
+/**
+ * Decorator implementation that replaces the decorated method with a cached
+ * version of itself.
+ *
+ * The wrapper is built lazily on the first call so that storages mounted after
+ * the container has been flushed - and defaults configured during bootstrap -
+ * are still picked up.
+ */
+export class CacheDecorator extends BaseDecorator<CacheTypes.DecoratorOptions> {
+  /** Cache manager owning the caching engine wiring */
+  @Inject(CacheManager)
+  protected gCacheManager!: CacheManager;
+
+  /** The untouched method, kept so it can be restored on destroy */
+  protected fOriginalMethod: ((...args: unknown[]) => unknown) | null = null;
+
+  /** Whether the method lived on the instance itself rather than on the prototype */
+  protected fOwnMethod: boolean = false;
+
+  /**
+   * Replaces the decorated method with its cached counterpart.
+   *
+   * @returns {void}
+   */
+  public override created(): void {
+    const original = this.instance[this.propertyName];
+
+    if (typeof original !== 'function') {
+      throw new CacheError('@Cache() can only be applied to methods', 'decorate', undefined, {
+        property: this.propertyName,
+        received: typeof original,
+      });
+    }
+
+    this.fOriginalMethod = original;
+    this.fOwnMethod = Object.hasOwn(this.instance, this.propertyName);
+
+    const owner = this.instance?.constructor?.name ?? 'anonymous';
+    const options: CacheTypes.DecoratorOptions = {
+      name: `${owner}.${this.propertyName}`,
+      integrity: hash([original, this.options ?? {}]),
+      ...this.options,
+    };
+
+    let cached: CacheTypes.CachedFunction | null = null;
+
+    const resolveCached = (): CacheTypes.CachedFunction => {
+      cached ??= this.gCacheManager.cached((...args: unknown[]) => original.apply(this.instance, args), options);
+      return cached;
+    };
+
+    const wrapper = (...args: unknown[]): Promise<unknown> => resolveCached()(...args);
+
+    wrapper.resolveKeys = (...args: unknown[]): Promise<string[]> => resolveCached().resolveKeys(...args);
+    wrapper.invalidate = (...args: unknown[]): Promise<void> => resolveCached().invalidate(...args);
+    wrapper.expire = (...args: unknown[]): Promise<void> => resolveCached().expire(...args);
+
+    this.instance[this.propertyName] = wrapper;
+  }
+
+  /**
+   * Drops the cached wrapper and puts the original method back in place.
+   *
+   * A method defined on the instance itself (a class field holding a function)
+   * is written back, while a prototype method is simply uncovered by removing
+   * the wrapper the decorator added to the instance.
+   *
+   * @returns {void}
+   */
+  public override destroyed(): void {
+    if (!this.fOriginalMethod) {
+      return;
+    }
+
+    if (this.fOwnMethod) {
+      this.instance[this.propertyName] = this.fOriginalMethod;
+    } else {
+      delete this.instance[this.propertyName];
+    }
+
+    this.fOriginalMethod = null;
+    this.fOwnMethod = false;
+  }
+}
+
+/**
+ * Caches the result of the decorated method.
+ *
+ * The cache key is derived from the method's arguments, so every distinct set of
+ * arguments gets its own entry. Concurrent calls for the same key are coalesced
+ * into a single execution, and entries are automatically dropped when the method
+ * body or its cache options change.
+ *
+ * The decorated method gains three helpers, keyed exactly like the cached calls:
+ * `resolveKeys(...args)`, `invalidate(...args)` and `expire(...args)`.
+ *
+ * @param {CacheTypes.DecoratorOptions} [options] - Cache options for this method
+ * @returns {Function} The method decorator
+ *
+ * @example
+ * ```ts
+ * class UsersService {
+ *   @Cache({ maxAge: 60, swr: true, staleMaxAge: 300, storage: 'redis' })
+ *   public async getUser(id: string): Promise<User> {
+ *     return this.database.findUser(id);
+ *   }
+ * }
+ *
+ * await usersService.getUser('123');
+ * await (usersService.getUser as CacheTypes.CachedMethod<[string], User>).invalidate('123');
+ * ```
+ *
+ * @example
+ * ```ts
+ * // arguments that are not safely hashable (Request, streams, class instances)
+ * // should be projected into an explicit key
+ * class ReportsController {
+ *   @Cache({ maxAge: 300, getKey: (range: DateRange) => `${range.from}-${range.to}` })
+ *   public async report(range: DateRange): Promise<Report> {
+ *     return this.reports.build(range);
+ *   }
+ * }
+ * ```
+ */
+export function Cache(options: CacheTypes.DecoratorOptions = {}): Function {
+  return createDecorator(CacheDecorator, options);
+}

--- a/packages/cache/src/Errors/CacheError.ts
+++ b/packages/cache/src/Errors/CacheError.ts
@@ -1,0 +1,32 @@
+/**
+ * Custom error class for cache-related errors.
+ * Wraps underlying cache/storage errors with standardized error messages.
+ */
+export class CacheError extends Error {
+  /**
+   * The original error that caused this cache error
+   */
+  public readonly cause?: Error;
+
+  /**
+   * The cache operation that failed
+   */
+  public readonly operation: string;
+
+  /**
+   * Additional metadata about the error (non-sensitive)
+   */
+  public readonly metadata?: Record<string, unknown>;
+
+  constructor(message: string, operation: string, cause?: Error, metadata?: Record<string, unknown>) {
+    super(message);
+    this.name = 'CacheError';
+    this.operation = operation;
+    this.cause = cause;
+    this.metadata = metadata;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, CacheError);
+    }
+  }
+}

--- a/packages/cache/src/Services/CacheManager.ts
+++ b/packages/cache/src/Services/CacheManager.ts
@@ -1,0 +1,223 @@
+import { Container, Init, Inject, InjectOptional } from '@vercube/di';
+import { Logger } from '@vercube/logger';
+import { StorageManager } from '@vercube/storage';
+import { defineCachedFunction, expireCache, invalidateCache, resolveCacheKeys, setStorage, useStorage } from 'ocache';
+import { CacheError } from '../Errors/CacheError';
+import { cacheBaseForStorage, CacheStorageAdapter } from './CacheStorageAdapter';
+import type { CacheTypes } from '../Types/CacheTypes';
+import type { CacheOptions } from 'ocache';
+
+/**
+ * Central entry point of the cache module.
+ *
+ * The CacheManager owns the wiring between the caching engine and the storages
+ * mounted in `@vercube/storage`, holds the application wide defaults and exposes
+ * the imperative API used both directly and by the `@Cache()` decorator.
+ *
+ * @example
+ * ```ts
+ * container.bind(CacheManager);
+ *
+ * const cache = container.get(CacheManager);
+ * cache.configure({ maxAge: 60, swr: true, staleMaxAge: 300, storage: 'cache' });
+ *
+ * const getUser = cache.cached((id: string) => db.users.find(id), { name: 'getUser' });
+ *
+ * await getUser('123');            // resolves and stores
+ * await getUser('123');            // served from cache
+ * await getUser.invalidate('123'); // drops the entry
+ * ```
+ */
+export class CacheManager {
+  /** Container instance */
+  @Inject(Container)
+  protected gContainer!: Container;
+
+  /** Logger instance */
+  @InjectOptional(Logger)
+  protected gLogger!: Logger | null;
+
+  /** Application wide defaults applied to every cached function */
+  protected fDefaults: CacheTypes.Defaults = {};
+
+  /** Storage adapter bridging the caching engine onto the mounted storages */
+  protected fAdapter: CacheStorageAdapter | null = null;
+
+  /**
+   * Returns the storage adapter this manager installed into the caching engine.
+   *
+   * @returns {CacheStorageAdapter | null} The adapter, or null before initialization
+   */
+  public get adapter(): CacheStorageAdapter | null {
+    return this.fAdapter;
+  }
+
+  /**
+   * Returns the currently configured defaults.
+   *
+   * @returns {CacheTypes.Defaults} A copy of the active defaults
+   */
+  public get defaults(): CacheTypes.Defaults {
+    return { ...this.fDefaults };
+  }
+
+  /**
+   * Sets the application wide cache defaults. Values passed per cached function
+   * always win over these. Calling it repeatedly merges into the existing defaults.
+   *
+   * @param {CacheTypes.Defaults} defaults - Defaults to apply to every cached function
+   * @returns {void}
+   */
+  public configure(defaults: CacheTypes.Defaults): void {
+    this.fDefaults = { ...this.fDefaults, ...this.stripUndefined(defaults) };
+  }
+
+  /**
+   * Wraps a function with caching.
+   *
+   * The returned function keeps the original signature and adds `resolveKeys()`,
+   * `invalidate()` and `expire()` helpers keyed exactly like the cached calls, so
+   * no cache key ever has to be rebuilt by hand.
+   *
+   * @template T - Return type of the wrapped function
+   * @template ArgsT - Argument tuple of the wrapped function
+   * @param {(...args: ArgsT) => T | Promise<T>} fn - The function to cache
+   * @param {CacheTypes.Options<T, ArgsT>} [options] - Per-function cache options
+   * @returns {CacheTypes.CachedFunction<T, ArgsT>} The cached function
+   */
+  public cached<T, ArgsT extends unknown[] = any[]>(
+    fn: (...args: ArgsT) => T | Promise<T>,
+    options: CacheTypes.Options<T, ArgsT> = {},
+  ): CacheTypes.CachedFunction<T, ArgsT> {
+    if (typeof fn !== 'function') {
+      throw new CacheError('Cached target must be a function', 'cached', undefined, { received: typeof fn });
+    }
+
+    return defineCachedFunction<T, ArgsT>(fn, this.resolveOptions(options)) as CacheTypes.CachedFunction<T, ArgsT>;
+  }
+
+  /**
+   * Removes cached entries for the given arguments from every storage tier.
+   *
+   * Pass the same options (`name`, `group`, `storage`, `getKey`) the entry was
+   * cached with so the very same keys are resolved.
+   *
+   * @template ArgsT - Argument tuple the entry was cached under
+   * @param {CacheTypes.Options<any, ArgsT>} options - Options identifying the cached function
+   * @param {ArgsT} args - Arguments identifying the entry
+   * @returns {Promise<void>} Resolves once every tier has been cleared
+   */
+  public async invalidate<ArgsT extends unknown[] = any[]>(
+    options: CacheTypes.Options<any, ArgsT>,
+    ...args: ArgsT
+  ): Promise<void> {
+    await invalidateCache<ArgsT>({ options: this.resolveOptions(options), args });
+  }
+
+  /**
+   * Marks cached entries as stale without removing them.
+   *
+   * With `swr` enabled the stale value keeps being served (within `staleMaxAge`)
+   * while the next access refreshes it in the background; without it, the next
+   * call re-resolves before returning.
+   *
+   * @template ArgsT - Argument tuple the entry was cached under
+   * @param {CacheTypes.Options<any, ArgsT>} options - Options identifying the cached function
+   * @param {ArgsT} args - Arguments identifying the entry
+   * @returns {Promise<void>} Resolves once every tier has been marked
+   */
+  public async expire<ArgsT extends unknown[] = any[]>(options: CacheTypes.Options<any, ArgsT>, ...args: ArgsT): Promise<void> {
+    await expireCache<ArgsT>({ options: this.resolveOptions(options), args });
+  }
+
+  /**
+   * Resolves every storage key (one per storage tier) the given arguments cache under.
+   * Useful for debugging and for cache inspection tooling.
+   *
+   * @template ArgsT - Argument tuple the entry was cached under
+   * @param {CacheTypes.Options<any, ArgsT>} options - Options identifying the cached function
+   * @param {ArgsT} args - Arguments identifying the entry
+   * @returns {Promise<string[]>} The resolved storage keys
+   */
+  public async resolveKeys<ArgsT extends unknown[] = any[]>(
+    options: CacheTypes.Options<any, ArgsT>,
+    ...args: ArgsT
+  ): Promise<string[]> {
+    return resolveCacheKeys<ArgsT>({ options: this.resolveOptions(options), args });
+  }
+
+  /**
+   * Merges the configured defaults into per-function options and translates the
+   * Vercube `storage` option into the key base the storage adapter routes on.
+   *
+   * @template T - Return type of the cached function
+   * @template ArgsT - Argument tuple of the cached function
+   * @param {CacheTypes.Options<T, ArgsT>} options - Per-function cache options
+   * @returns {CacheOptions<T, ArgsT>} Options understood by the caching engine
+   * @protected
+   */
+  protected resolveOptions<T, ArgsT extends unknown[]>(options: CacheTypes.Options<T, ArgsT>): CacheOptions<T, ArgsT> {
+    const { storage, ...rest } = {
+      ...this.fDefaults,
+      ...this.stripUndefined(options),
+    } as CacheTypes.Options<T, ArgsT>;
+
+    const storages = Array.isArray(storage) ? storage : [storage];
+
+    if (storages.length === 0) {
+      // an empty tier list would make every read miss and every write a no-op,
+      // silently disabling the cache instead of failing where the mistake is
+      throw new CacheError('At least one storage must be given when caching', 'resolveOptions', undefined, {
+        name: rest.name,
+      });
+    }
+
+    const base = storages.map((name) => cacheBaseForStorage(name));
+
+    return {
+      ...rest,
+      base: base.length === 1 ? base[0] : base,
+    } as CacheOptions<T, ArgsT>;
+  }
+
+  /**
+   * Drops keys whose value is `undefined`, so that an explicitly passed
+   * `undefined` never shadows a configured default with a missing value.
+   *
+   * @template T - Shape of the option object
+   * @param {T} options - Options to clean up
+   * @returns {Partial<T>} The options without undefined values
+   * @protected
+   */
+  protected stripUndefined<T extends object>(options: T): Partial<T> {
+    return Object.fromEntries(Object.entries(options).filter(([, value]) => value !== undefined)) as Partial<T>;
+  }
+
+  /**
+   * Installs the storage adapter into the caching engine.
+   * Called automatically with the `@Init()` decorator.
+   *
+   * @returns {void}
+   * @protected
+   */
+  @Init()
+  protected init(): void {
+    if (!this.gContainer.getOptional(StorageManager)) {
+      this.gLogger?.warn(
+        'Vercube/CacheManager::StorageManager is not registered - bind it so cached entries have a storage to live in',
+      );
+    }
+
+    // the caching engine keeps a single process-wide storage, so a second
+    // CacheManager takes over every cached function in the process
+    if (useStorage() instanceof CacheStorageAdapter) {
+      this.gLogger?.warn(
+        'Vercube/CacheManager::another CacheManager is already installed in this process - ' +
+          'cached functions from every container will now route through this one',
+      );
+    }
+
+    this.fAdapter = this.gContainer.resolve(CacheStorageAdapter);
+    setStorage(this.fAdapter);
+  }
+}

--- a/packages/cache/src/Services/CacheStorageAdapter.ts
+++ b/packages/cache/src/Services/CacheStorageAdapter.ts
@@ -1,0 +1,191 @@
+import { InjectOptional } from '@vercube/di';
+import { Logger } from '@vercube/logger';
+import { StorageManager } from '@vercube/storage';
+import { MemoryStorage } from '@vercube/storage/drivers/MemoryStorage';
+import { CacheError } from '../Errors/CacheError';
+import type { Storage } from '@vercube/storage';
+import type { StorageInterface } from 'ocache';
+
+/**
+ * Prefix every cache key starts with. The segment that follows it (when present)
+ * is the name of the storage mounted in {@link StorageManager} that backs the entry.
+ *
+ * ocache builds keys as `<base>:<group>:<name>:<key>.json`, so the base is always
+ * the first colon separated segment and can be parsed back out on read/write.
+ */
+export const CACHE_BASE_PREFIX = '/cache';
+
+/**
+ * Builds the cache key base for a storage mounted in {@link StorageManager}.
+ *
+ * @param {string} [storage] - Name of the mounted storage, `default` when omitted
+ * @returns {string} The base prefix cache keys for that storage start with
+ */
+export function cacheBaseForStorage(storage?: string): string {
+  if (storage?.includes(':')) {
+    // the base is read back by splitting on the first colon, so a colon in the
+    // name would silently resolve to a different (or non-existent) storage
+    throw new CacheError('Storage name used for caching must not contain a colon', 'cacheBaseForStorage', undefined, {
+      storage,
+    });
+  }
+
+  return storage && storage !== 'default' ? `${CACHE_BASE_PREFIX}/${storage}` : CACHE_BASE_PREFIX;
+}
+
+/**
+ * Extracts the mounted storage name back out of a full cache key.
+ *
+ * @param {string} key - A cache key produced by the caching engine
+ * @returns {string} Name of the storage the key belongs to, `default` when the key carries no storage segment
+ */
+export function storageNameFromCacheKey(key: string): string {
+  const separatorIndex = key.indexOf(':');
+  const base = separatorIndex === -1 ? key : key.slice(0, separatorIndex);
+
+  if (!base.startsWith(`${CACHE_BASE_PREFIX}/`)) {
+    return 'default';
+  }
+
+  return base.slice(CACHE_BASE_PREFIX.length + 1) || 'default';
+}
+
+/**
+ * Bridges the caching engine onto the Vercube {@link StorageManager}.
+ *
+ * The cache module owns no storage of its own - every entry lives in a storage
+ * mounted in `@vercube/storage`, so a cache can be backed by memory, S3 or any
+ * other driver simply by mounting it, and the very same entries are visible
+ * through the regular storage API.
+ *
+ * Every cache key carries the name of the storage it belongs to in its base
+ * segment, so a single adapter instance serves cached functions that live in
+ * different storages - and even ones that span several of them at once.
+ *
+ * A cached function may point at a storage that has not been mounted; in that
+ * case a {@link MemoryStorage} is mounted under that name on first use so that
+ * caching works with zero configuration. Mounting the name yourself - before or
+ * after - is what swaps the backend for a real one.
+ */
+export class CacheStorageAdapter implements StorageInterface {
+  /** Storage manager holding every mounted storage */
+  @InjectOptional(StorageManager)
+  protected gStorageManager!: StorageManager | null;
+
+  /** Logger instance */
+  @InjectOptional(Logger)
+  protected gLogger!: Logger | null;
+
+  /** In-flight auto-mounts, keyed by storage name, so concurrent calls share one storage */
+  protected fMounting: Map<string, Promise<Storage>> = new Map();
+
+  /**
+   * Reads a cache entry from the storage its key points at.
+   *
+   * @template T - Type of the stored entry
+   * @param {string} key - Full cache key, including the storage base prefix
+   * @returns {Promise<T | null>} The stored entry, or null when it is absent
+   */
+  public async get<T = unknown>(key: string): Promise<T | null> {
+    const storage = await this.resolveStorage(key);
+    return (await storage.getItem<T>(key)) ?? null;
+  }
+
+  /**
+   * Writes a cache entry to the storage its key points at.
+   *
+   * The caching engine signals a deletion by writing `null`, which is mapped onto
+   * the storage's delete operation so that no empty entries are left behind.
+   *
+   * @template T - Type of the value to store
+   * @param {string} key - Full cache key, including the storage base prefix
+   * @param {T} value - Entry to store, or null to remove it
+   * @param {{ ttl?: number }} [opts] - Storage hints, `ttl` in seconds
+   * @returns {Promise<void>} Resolves once the write is complete
+   */
+  public async set<T = unknown>(key: string, value: T, opts?: { ttl?: number }): Promise<void> {
+    const storage = await this.resolveStorage(key);
+
+    if (value === null || value === undefined) {
+      await storage.deleteItem(key);
+      return;
+    }
+
+    await storage.setItem<T, { ttl?: number }>(key, value, opts);
+  }
+
+  /**
+   * Resolves the mounted storage a cache key belongs to, mounting an in-memory
+   * one under that name when nothing has been mounted yet.
+   *
+   * @param {string} key - Full cache key, including the storage base prefix
+   * @returns {Promise<Storage>} The storage backing that key
+   * @protected
+   */
+  protected async resolveStorage(key: string): Promise<Storage> {
+    const manager = this.gStorageManager;
+
+    if (!manager) {
+      throw new CacheError(
+        'StorageManager is not registered in the container - bind it so cached entries have a storage to live in',
+        'resolveStorage',
+        undefined,
+        { key },
+      );
+    }
+
+    const name = storageNameFromCacheKey(key);
+
+    return manager.getStorage(name) ?? (await this.mountFallback(manager, name));
+  }
+
+  /**
+   * Mounts an in-memory storage under the given name, so that a cached function
+   * pointing at a storage nobody mounted still works.
+   *
+   * @param {StorageManager} manager - Storage manager to mount into
+   * @param {string} name - Name of the storage to mount
+   * @returns {Promise<Storage>} The freshly mounted storage
+   * @protected
+   */
+  protected async mountFallback(manager: StorageManager, name: string): Promise<Storage> {
+    const pending = this.fMounting.get(name);
+
+    if (pending) {
+      return pending;
+    }
+
+    const mounting = (async () => {
+      await manager.mount({ name, storage: MemoryStorage });
+
+      const storage = manager.getStorage(name);
+
+      if (!storage) {
+        throw new CacheError('Unable to mount a fallback cache storage', 'mountFallback', undefined, { storage: name });
+      }
+
+      // mount() does not initialize, that only happens for storages present at container flush
+      await storage.initialize(undefined);
+
+      this.gLogger?.warn(
+        `Vercube/CacheStorageAdapter::storage "${name}" was not mounted, an in-memory one has been mounted automatically`,
+      );
+
+      return storage;
+    })();
+
+    this.fMounting.set(name, mounting);
+
+    // drop the entry once it settles: a mounted storage is found through the manager
+    // from then on, and a failed mount must stay retryable instead of being cached
+    void mounting
+      .catch(() => undefined)
+      .finally(() => {
+        if (this.fMounting.get(name) === mounting) {
+          this.fMounting.delete(name);
+        }
+      });
+
+    return mounting;
+  }
+}

--- a/packages/cache/src/Types/CacheTypes.ts
+++ b/packages/cache/src/Types/CacheTypes.ts
@@ -1,0 +1,92 @@
+import type { CacheEntry, CacheOptions, CacheStatus } from 'ocache';
+
+export namespace CacheTypes {
+  /**
+   * Name (or ordered list of names) of storages mounted in the {@link StorageManager}
+   * that should back a cached function.
+   *
+   * When an array is given, reads try each storage in order (multi-tier: hit the fast
+   * one first, fall back to the shared one) and writes go to all of them.
+   *
+   * When omitted, the `default` storage is used.
+   */
+  export type StorageRef = string | string[];
+
+  /**
+   * How a cached value was served on a given call.
+   * - `hit` - a fresh cached value was returned without re-resolving
+   * - `stale` - a stale value was served while a background SWR refresh runs
+   * - `revalidated` - a prior value existed but was expired, so it was re-resolved in the foreground
+   * - `miss` - the value was resolved fresh on this call
+   */
+  export type Status = CacheStatus;
+
+  /**
+   * A cache entry as it is stored, wrapping the cached value with its metadata.
+   */
+  export type Entry<T = unknown> = CacheEntry<T>;
+
+  /**
+   * Options accepted by {@link CacheManager.cached} and the `@Cache()` decorator.
+   *
+   * This is the ocache option set with the low level `base` option replaced by the
+   * Vercube native `storage` option - `base` is derived from it so that cache keys
+   * can be routed to the right mounted storage.
+   */
+  export type Options<T = any, ArgsT extends unknown[] = any[]> = Omit<CacheOptions<T, ArgsT>, 'base'> & {
+    /** Storage (or storages, for multi-tier caching) mounted in StorageManager to keep entries in. */
+    storage?: StorageRef;
+  };
+
+  /**
+   * Application wide defaults applied to every cached function.
+   * Per-call options always win over these.
+   */
+  export interface Defaults {
+    /** Number of seconds an entry stays fresh. @default 1 */
+    maxAge?: number;
+    /** Serve a stale entry while refreshing it in the background. @default false */
+    swr?: boolean;
+    /** Maximum number of seconds a stale entry may be served while revalidating. */
+    staleMaxAge?: number;
+    /** Cache key group prefix. @default 'functions' */
+    group?: string;
+    /** Default storage (or storages) to keep entries in. */
+    storage?: StorageRef;
+    /** Called for every cache related error (read, write, background refresh). */
+    onError?: (error: unknown) => void;
+  }
+
+  /**
+   * A function wrapped with caching, augmented with on-demand revalidation helpers.
+   */
+  export type CachedFunction<T = unknown, ArgsT extends unknown[] = any[]> = {
+    (...args: ArgsT): Promise<T>;
+    /** Resolves every storage key (one per storage tier) the given arguments cache under. */
+    resolveKeys: (...args: ArgsT) => Promise<string[]>;
+    /** Removes cached entries for the given arguments from every storage tier. */
+    invalidate: (...args: ArgsT) => Promise<void>;
+    /** Marks cached entries as stale so the next access refreshes them. */
+    expire: (...args: ArgsT) => Promise<void>;
+  };
+
+  /**
+   * Options for the `@Cache()` decorator. Identical to {@link Options}, except that
+   * `name` defaults to `ClassName.methodName` when it is not given.
+   */
+  export type DecoratorOptions<T = any, ArgsT extends unknown[] = any[]> = Options<T, ArgsT>;
+
+  /**
+   * A method wrapped by the `@Cache()` decorator, as seen from the outside.
+   * Use it to type a cached method so its `.invalidate()` / `.expire()` helpers are visible.
+   *
+   * @example
+   * ```ts
+   * class UsersService {
+   *   @Cache({ maxAge: 60 })
+   *   public getUser!: CacheTypes.CachedMethod<[id: string], User>;
+   * }
+   * ```
+   */
+  export type CachedMethod<ArgsT extends unknown[] = any[], T = unknown> = CachedFunction<T, ArgsT>;
+}

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -1,0 +1,12 @@
+// Decorators
+export * from './Decorators/Cache';
+
+// Services
+export * from './Services/CacheManager';
+export * from './Services/CacheStorageAdapter';
+
+// Errors
+export * from './Errors/CacheError';
+
+// Types
+export * from './Types/CacheTypes';

--- a/packages/cache/test/Cache.test.ts
+++ b/packages/cache/test/Cache.test.ts
@@ -1,0 +1,333 @@
+import { Container, initializeContainer } from '@vercube/di';
+import { Logger } from '@vercube/logger';
+import { Storage, StorageManager } from '@vercube/storage';
+import { MemoryStorage } from '@vercube/storage/drivers/MemoryStorage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Cache, CacheDecorator, CacheError, CacheManager } from '../src';
+import type { CacheTypes } from '../src';
+
+const calls = {
+  getUser: vi.fn(),
+  listUsers: vi.fn(),
+  report: vi.fn(),
+  named: vi.fn(),
+  secondary: vi.fn(),
+};
+
+class UsersService {
+  @Cache({ maxAge: 60 })
+  public async getUser(id: string): Promise<string> {
+    calls.getUser(id);
+    return `user-${id}`;
+  }
+
+  @Cache({ maxAge: 60 })
+  public async listUsers(): Promise<string[]> {
+    calls.listUsers();
+    return ['a', 'b'];
+  }
+
+  @Cache({ maxAge: 60, getKey: (range: { from: string; to: string }) => `${range.from}:${range.to}` })
+  public async report(range: { from: string; to: string; trace?: string }): Promise<string> {
+    calls.report(range);
+    return `${range.from}-${range.to}`;
+  }
+
+  @Cache({ name: 'custom-name', maxAge: 60 })
+  public async named(): Promise<string> {
+    calls.named();
+    return 'named';
+  }
+
+  @Cache({ maxAge: 60, storage: 'secondary' })
+  public async secondary(): Promise<string> {
+    calls.secondary();
+    return 'secondary';
+  }
+}
+
+/** Second class declaring a method with the very same name, to prove keys do not collide */
+class AccountsService {
+  @Cache({ maxAge: 60 })
+  public async getUser(id: string): Promise<string> {
+    return `account-${id}`;
+  }
+}
+
+describe('@Cache', () => {
+  let container: Container;
+  let storageManager: StorageManager;
+  let usersService: UsersService;
+
+  beforeEach(async () => {
+    for (const spy of Object.values(calls)) {
+      spy.mockClear();
+    }
+
+    container = new Container();
+
+    container.bindInstance(Container, container);
+    container.bindInstance(Logger, {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger);
+    container.bind(StorageManager);
+    container.bind(Storage);
+    container.bind(MemoryStorage);
+    container.bind(CacheManager);
+    container.bind(UsersService);
+    container.bind(AccountsService);
+    initializeContainer(container);
+
+    storageManager = container.get(StorageManager);
+    await storageManager.mount({ storage: MemoryStorage });
+    await storageManager.mount({ name: 'secondary', storage: MemoryStorage });
+
+    usersService = container.get(UsersService);
+  });
+
+  describe('caching', () => {
+    it('should call the method only once for the same arguments', async () => {
+      await expect(usersService.getUser('1')).resolves.toBe('user-1');
+      await expect(usersService.getUser('1')).resolves.toBe('user-1');
+
+      expect(calls.getUser).toHaveBeenCalledOnce();
+    });
+
+    it('should keep a separate entry per argument set', async () => {
+      await expect(usersService.getUser('1')).resolves.toBe('user-1');
+      await expect(usersService.getUser('2')).resolves.toBe('user-2');
+      await expect(usersService.getUser('1')).resolves.toBe('user-1');
+
+      expect(calls.getUser).toHaveBeenCalledTimes(2);
+    });
+
+    it('should cache methods without arguments', async () => {
+      await expect(usersService.listUsers()).resolves.toEqual(['a', 'b']);
+      await expect(usersService.listUsers()).resolves.toEqual(['a', 'b']);
+
+      expect(calls.listUsers).toHaveBeenCalledOnce();
+    });
+
+    it('should keep `this` bound to the owning instance', async () => {
+      class Counter {
+        private fBase = 10;
+
+        @Cache({ maxAge: 60 })
+        public async value(): Promise<number> {
+          return this.fBase + 1;
+        }
+      }
+
+      container.bind(Counter);
+      container.expand(() => {});
+
+      await expect(container.get(Counter).value()).resolves.toBe(11);
+    });
+
+    it('should share entries between two instances of the same class', async () => {
+      // the key is built from the class name, the method name and the arguments -
+      // instance identity is deliberately not part of it
+      container.bind('UsersServiceAlias', UsersService);
+      container.expand(() => {});
+
+      const other = container.get<UsersService>('UsersServiceAlias');
+      expect(other).not.toBe(usersService);
+
+      await expect(usersService.getUser('1')).resolves.toBe('user-1');
+      await expect(other.getUser('1')).resolves.toBe('user-1');
+
+      expect(calls.getUser).toHaveBeenCalledOnce();
+    });
+
+    it('should not collide with a same-named method on another class', async () => {
+      await expect(usersService.getUser('1')).resolves.toBe('user-1');
+      await expect(container.get(AccountsService).getUser('1')).resolves.toBe('account-1');
+    });
+
+    it('should honour a custom key derivation', async () => {
+      await usersService.report({ from: 'a', to: 'b', trace: '1' });
+      await usersService.report({ from: 'a', to: 'b', trace: '2' });
+
+      expect(calls.report).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('keys', () => {
+    it('should default the cache name to Class.method', async () => {
+      await usersService.getUser('1');
+
+      const keys = await storageManager.getKeys({});
+      expect(keys.some((key) => key.startsWith('/cache:functions:UsersService.getUser:'))).toBe(true);
+    });
+
+    it('should use an explicit name when given', async () => {
+      await usersService.named();
+
+      const keys = await storageManager.getKeys({});
+      expect(keys.some((key) => key.startsWith('/cache:functions:custom-name:'))).toBe(true);
+    });
+
+    it('should store entries in the requested storage', async () => {
+      await usersService.secondary();
+
+      await expect(storageManager.size({})).resolves.toBe(0);
+      await expect(storageManager.size({ storage: 'secondary' })).resolves.toBe(1);
+    });
+  });
+
+  describe('revalidation helpers', () => {
+    it('should expose resolveKeys on the decorated method', async () => {
+      const getUser = usersService.getUser as unknown as CacheTypes.CachedMethod<[string], string>;
+
+      await usersService.getUser('1');
+      const [key] = await getUser.resolveKeys('1');
+
+      await expect(storageManager.hasItem({ key })).resolves.toBe(true);
+    });
+
+    it('should drop the entry through invalidate', async () => {
+      const getUser = usersService.getUser as unknown as CacheTypes.CachedMethod<[string], string>;
+
+      await usersService.getUser('1');
+      await getUser.invalidate('1');
+      await usersService.getUser('1');
+
+      expect(calls.getUser).toHaveBeenCalledTimes(2);
+    });
+
+    it('should only invalidate the matching argument set', async () => {
+      const getUser = usersService.getUser as unknown as CacheTypes.CachedMethod<[string], string>;
+
+      await usersService.getUser('1');
+      await usersService.getUser('2');
+      await getUser.invalidate('1');
+      await usersService.getUser('2');
+
+      expect(calls.getUser).toHaveBeenCalledTimes(2);
+    });
+
+    it('should key the helpers through a custom getKey', async () => {
+      const report = usersService.report as unknown as CacheTypes.CachedMethod<
+        [{ from: string; to: string; trace?: string }],
+        string
+      >;
+
+      await usersService.report({ from: 'a', to: 'b', trace: '1' });
+
+      // the helper must project the key the same way the cached call did,
+      // so a differing `trace` still resolves to the very same entry
+      const [key] = await report.resolveKeys({ from: 'a', to: 'b', trace: '2' });
+      await expect(storageManager.hasItem({ key })).resolves.toBe(true);
+
+      await report.invalidate({ from: 'a', to: 'b', trace: '3' });
+      await usersService.report({ from: 'a', to: 'b', trace: '4' });
+
+      expect(calls.report).toHaveBeenCalledTimes(2);
+    });
+
+    it('should mark the entry stale through expire', async () => {
+      const getUser = usersService.getUser as unknown as CacheTypes.CachedMethod<[string], string>;
+
+      await usersService.getUser('1');
+      await getUser.expire('1');
+      await usersService.getUser('1');
+
+      expect(calls.getUser).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('integrity', () => {
+    it('should drop entries written by a different method body', async () => {
+      const getUser = usersService.getUser as unknown as CacheTypes.CachedMethod<[string], string>;
+      const [key] = await getUser.resolveKeys('1');
+
+      await storageManager.setItem({
+        key,
+        value: { value: 'stale-from-another-build', mtime: Date.now(), integrity: 'other-integrity' },
+      });
+
+      await expect(usersService.getUser('1')).resolves.toBe('user-1');
+      expect(calls.getUser).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('should reject decorating a non-method property', () => {
+      const decorator = container.resolve(CacheDecorator);
+      decorator.options = {};
+      decorator.instance = { notAMethod: 'nope' };
+      decorator.propertyName = 'notAMethod';
+
+      expect(() => decorator.created()).toThrow(CacheError);
+    });
+
+    it('should fall back to an anonymous owner when the instance has no constructor', async () => {
+      const decorator = container.resolve(CacheDecorator);
+      const instance = Object.create(null) as Record<string, unknown>;
+
+      instance.value = async () => 'value';
+
+      // options left unset on purpose - the decorator must cope with a missing options object
+      decorator.instance = instance;
+      decorator.propertyName = 'value';
+      decorator.created();
+
+      await (instance.value as () => Promise<string>)();
+
+      const keys = await storageManager.getKeys({});
+      expect(keys.some((key) => key.startsWith('/cache:functions:anonymous.value:'))).toBe(true);
+    });
+
+    it('should restore the original method on destroy', async () => {
+      const decorator = container.resolve(CacheDecorator);
+      const instance = new UsersService();
+
+      decorator.options = { maxAge: 60 };
+      decorator.instance = instance;
+      decorator.propertyName = 'listUsers';
+
+      decorator.created();
+      expect(Object.hasOwn(instance, 'listUsers')).toBe(true);
+
+      decorator.destroyed();
+      expect(Object.hasOwn(instance, 'listUsers')).toBe(false);
+    });
+
+    it('should put back a method that lived on the instance itself', () => {
+      const decorator = container.resolve(CacheDecorator);
+      const original = async (): Promise<string> => 'own';
+      const instance = { value: original };
+
+      decorator.options = { maxAge: 60 };
+      decorator.instance = instance;
+      decorator.propertyName = 'value';
+
+      decorator.created();
+      expect(instance.value).not.toBe(original);
+
+      // deleting would drop a class-field method entirely, so it is written back
+      decorator.destroyed();
+      expect(instance.value).toBe(original);
+    });
+
+    it('should be safe to destroy twice or without a preceding create', () => {
+      const decorator = container.resolve(CacheDecorator);
+      const instance = new UsersService();
+
+      decorator.options = { maxAge: 60 };
+      decorator.instance = instance;
+      decorator.propertyName = 'listUsers';
+
+      expect(() => decorator.destroyed()).not.toThrow();
+
+      decorator.created();
+      decorator.destroyed();
+
+      expect(() => decorator.destroyed()).not.toThrow();
+      expect(typeof instance.listUsers).toBe('function');
+    });
+  });
+});

--- a/packages/cache/test/CacheManager.test.ts
+++ b/packages/cache/test/CacheManager.test.ts
@@ -1,0 +1,451 @@
+import { Container, initializeContainer } from '@vercube/di';
+import { Logger } from '@vercube/logger';
+import { Storage, StorageManager } from '@vercube/storage';
+import { MemoryStorage } from '@vercube/storage/drivers/MemoryStorage';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CacheError, CacheManager } from '../src';
+import { BrokenStorage } from './Utils/Mock.mock';
+import type { CacheTypes } from '../src';
+
+describe('CacheManager', () => {
+  let container: Container;
+  let storageManager: StorageManager;
+  let cacheManager: CacheManager;
+
+  beforeEach(async () => {
+    container = new Container();
+
+    container.bindInstance(Container, container);
+    container.bindInstance(Logger, {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger);
+    container.bind(StorageManager);
+    container.bind(Storage);
+    container.bind(MemoryStorage);
+    container.bind(CacheManager);
+    initializeContainer(container);
+
+    storageManager = container.get(StorageManager);
+    await storageManager.mount({ storage: MemoryStorage });
+    await storageManager.mount({ name: 'secondary', storage: MemoryStorage });
+
+    cacheManager = container.get(CacheManager);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('initialization', () => {
+    it('should install the storage adapter on init', () => {
+      expect(cacheManager.adapter).not.toBeNull();
+    });
+
+    it('should warn when no StorageManager is bound', () => {
+      const bare = new Container();
+      const bareLogger = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() } as unknown as Logger;
+
+      bare.bindInstance(Container, bare);
+      bare.bindInstance(Logger, bareLogger);
+      bare.bind(CacheManager);
+      initializeContainer(bare);
+
+      expect(bareLogger.warn).toHaveBeenCalledWith(expect.stringContaining('StorageManager is not registered'));
+    });
+  });
+
+  describe('resilience', () => {
+    it('should still resolve the value when the storage cannot be read or written', async () => {
+      await storageManager.mount({ name: 'broken', storage: BrokenStorage });
+
+      const onError = vi.fn();
+      const resolver = vi.fn(async () => 'value');
+      const cached = cacheManager.cached(resolver, { name: 'broken', maxAge: 60, storage: 'broken', onError });
+
+      // a cache that cannot store anything degrades into calling through every time
+      await expect(cached()).resolves.toBe('value');
+      await expect(cached()).resolves.toBe('value');
+
+      expect(resolver).toHaveBeenCalledTimes(2);
+      expect(onError).toHaveBeenCalled();
+      expect(onError.mock.calls.every(([error]) => error instanceof Error)).toBe(true);
+    });
+
+    it('should propagate failures from an explicit invalidate or expire', async () => {
+      await storageManager.mount({ name: 'broken', storage: BrokenStorage });
+
+      const options = { name: 'broken-invalidate', maxAge: 60, storage: 'broken' };
+
+      // unlike a cached call, an explicitly requested write is not swallowed
+      await expect(cacheManager.invalidate(options)).rejects.toThrow('storage delete failed');
+      await expect(cacheManager.expire(options)).rejects.toThrow('storage read failed');
+    });
+
+    it('should report read and write failures separately', async () => {
+      await storageManager.mount({ name: 'broken', storage: BrokenStorage });
+
+      const onError = vi.fn();
+      const cached = cacheManager.cached(async () => 'value', {
+        name: 'broken-split',
+        maxAge: 60,
+        storage: 'broken',
+        onError,
+      });
+
+      await cached();
+
+      const messages = onError.mock.calls.map(([error]) => (error as Error).message);
+      expect(messages).toContain('storage read failed');
+      expect(messages).toContain('storage write failed');
+    });
+  });
+
+  describe('option pass-through', () => {
+    it('should honour shouldBypassCache', async () => {
+      const resolver = vi.fn(async (id: string) => `user-${id}`);
+      const cached = cacheManager.cached(resolver, {
+        name: 'bypass',
+        maxAge: 60,
+        shouldBypassCache: (id) => id === 'fresh',
+      });
+
+      await cached('fresh');
+      await cached('fresh');
+      await cached('cached');
+      await cached('cached');
+
+      expect(resolver).toHaveBeenCalledTimes(3);
+    });
+
+    it('should honour shouldInvalidateCache', async () => {
+      let invalidate = false;
+      const resolver = vi.fn(async () => 'value');
+      const cached = cacheManager.cached(resolver, {
+        name: 'invalidate-hook',
+        maxAge: 60,
+        shouldInvalidateCache: () => invalidate,
+      });
+
+      await cached();
+      await cached();
+      expect(resolver).toHaveBeenCalledOnce();
+
+      invalidate = true;
+      await cached();
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it('should honour validate', async () => {
+      const resolver = vi.fn(async () => 'value');
+      const cached = cacheManager.cached(resolver, {
+        name: 'validate',
+        maxAge: 60,
+        validate: () => false,
+      });
+
+      await cached();
+      await cached();
+
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it('should expose the serve status to transform', async () => {
+      const seen: (CacheTypes.Status | undefined)[] = [];
+      const cached = cacheManager.cached(async () => 'value', {
+        name: 'status',
+        maxAge: 60,
+        transform: (entry) => {
+          seen.push(entry.status);
+          return entry.value;
+        },
+      });
+
+      await cached();
+      await cached();
+
+      expect(seen).toEqual(['miss', 'hit']);
+    });
+
+    it('should derive the lifetime through getMaxAge', async () => {
+      vi.useFakeTimers();
+
+      const resolver = vi.fn(async () => ({ expiresIn: 10 }));
+      const cached = cacheManager.cached(resolver, {
+        name: 'get-max-age',
+        maxAge: 3600,
+        getMaxAge: (entry) => entry.value?.expiresIn,
+      });
+
+      await cached();
+      vi.advanceTimersByTime(11_000);
+      await cached();
+
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it('should separate entries by group', async () => {
+      const options = { name: 'grouped', maxAge: 60 };
+
+      await cacheManager.cached(async () => 'a', { ...options, group: 'one' })();
+      await cacheManager.cached(async () => 'b', { ...options, group: 'two' })();
+
+      const keys = await storageManager.getKeys({});
+      expect(keys.some((key) => key.startsWith('/cache:one:grouped:'))).toBe(true);
+      expect(keys.some((key) => key.startsWith('/cache:two:grouped:'))).toBe(true);
+    });
+  });
+
+  describe('cached', () => {
+    it('should resolve the value only once for the same arguments', async () => {
+      const resolver = vi.fn(async (id: string) => `user-${id}`);
+      const cached = cacheManager.cached(resolver, { name: 'getUser', maxAge: 60 });
+
+      await expect(cached('1')).resolves.toBe('user-1');
+      await expect(cached('1')).resolves.toBe('user-1');
+
+      expect(resolver).toHaveBeenCalledOnce();
+    });
+
+    it('should keep a separate entry per argument set', async () => {
+      const resolver = vi.fn(async (id: string) => `user-${id}`);
+      const cached = cacheManager.cached(resolver, { name: 'getUser', maxAge: 60 });
+
+      await expect(cached('1')).resolves.toBe('user-1');
+      await expect(cached('2')).resolves.toBe('user-2');
+
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it('should coalesce concurrent calls into a single resolution', async () => {
+      const resolver = vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return 'value';
+      });
+      const cached = cacheManager.cached(resolver, { name: 'concurrent', maxAge: 60 });
+
+      await Promise.all([cached(), cached(), cached()]);
+
+      expect(resolver).toHaveBeenCalledOnce();
+    });
+
+    it('should re-resolve once the entry is no longer fresh', async () => {
+      vi.useFakeTimers();
+
+      const resolver = vi.fn(async () => Date.now());
+      const cached = cacheManager.cached(resolver, { name: 'ttl', maxAge: 10 });
+
+      await cached();
+      vi.advanceTimersByTime(5000);
+      await cached();
+      expect(resolver).toHaveBeenCalledOnce();
+
+      vi.advanceTimersByTime(6000);
+      await cached();
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it('should honour a custom key derivation', async () => {
+      const resolver = vi.fn(async (input: { id: string; trace: string }) => input.id);
+      const cached = cacheManager.cached(resolver, {
+        name: 'custom-key',
+        maxAge: 60,
+        getKey: (input) => input.id,
+      });
+
+      await cached({ id: '1', trace: 'a' });
+      await cached({ id: '1', trace: 'b' });
+
+      expect(resolver).toHaveBeenCalledOnce();
+    });
+
+    it('should reject non-function targets', () => {
+      expect(() => cacheManager.cached('nope' as unknown as () => void)).toThrow(CacheError);
+    });
+  });
+
+  describe('storage routing', () => {
+    it('should store entries in the default storage', async () => {
+      const cached = cacheManager.cached(async () => 'value', { name: 'default-storage', maxAge: 60 });
+      await cached();
+
+      const keys = await storageManager.getKeys({});
+      expect(keys.some((key) => key.startsWith('/cache:functions:default-storage:'))).toBe(true);
+      await expect(storageManager.size({ storage: 'secondary' })).resolves.toBe(0);
+    });
+
+    it('should store entries in the requested storage', async () => {
+      const cached = cacheManager.cached(async () => 'value', {
+        name: 'named-storage',
+        maxAge: 60,
+        storage: 'secondary',
+      });
+      await cached();
+
+      await expect(storageManager.size({})).resolves.toBe(0);
+      await expect(storageManager.size({ storage: 'secondary' })).resolves.toBe(1);
+    });
+
+    it('should write to every tier when several storages are given', async () => {
+      const cached = cacheManager.cached(async () => 'value', {
+        name: 'tiered',
+        maxAge: 60,
+        storage: ['default', 'secondary'],
+      });
+      await cached();
+
+      await expect(storageManager.size({})).resolves.toBe(1);
+      await expect(storageManager.size({ storage: 'secondary' })).resolves.toBe(1);
+    });
+
+    it('should fall through to the slower tier when the faster one misses', async () => {
+      const resolver = vi.fn(async () => 'value');
+      const options = { name: 'tiered-read', maxAge: 60, storage: ['default', 'secondary'] };
+
+      // seed both tiers, then drop the fast one only
+      await cacheManager.cached(resolver, options)();
+      const [fastKey] = await cacheManager.resolveKeys({ ...options, storage: 'default' });
+      await storageManager.deleteItem({ key: fastKey });
+      await expect(storageManager.size({})).resolves.toBe(0);
+
+      await expect(cacheManager.cached(resolver, options)()).resolves.toBe('value');
+
+      expect(resolver).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('defaults', () => {
+    it('should apply configured defaults', async () => {
+      cacheManager.configure({ maxAge: 60, storage: 'secondary' });
+
+      const cached = cacheManager.cached(async () => 'value', { name: 'with-defaults' });
+      await cached();
+
+      await expect(storageManager.size({ storage: 'secondary' })).resolves.toBe(1);
+      expect(cacheManager.defaults).toEqual({ maxAge: 60, storage: 'secondary' });
+    });
+
+    it('should let per-function options win over defaults', async () => {
+      cacheManager.configure({ storage: 'secondary' });
+
+      const cached = cacheManager.cached(async () => 'value', { name: 'override', maxAge: 60, storage: 'default' });
+      await cached();
+
+      await expect(storageManager.size({})).resolves.toBe(1);
+      await expect(storageManager.size({ storage: 'secondary' })).resolves.toBe(0);
+    });
+
+    it('should merge repeated configure calls', () => {
+      cacheManager.configure({ maxAge: 30 });
+      cacheManager.configure({ swr: true });
+
+      expect(cacheManager.defaults).toEqual({ maxAge: 30, swr: true });
+    });
+
+    it('should ignore explicitly undefined defaults', async () => {
+      vi.useFakeTimers();
+
+      cacheManager.configure({ maxAge: 10 });
+      cacheManager.configure({ maxAge: undefined });
+
+      expect(cacheManager.defaults).toEqual({ maxAge: 10 });
+
+      // an undefined default must not wipe the freshness window
+      const resolver = vi.fn(async () => 'value');
+      const cached = cacheManager.cached(resolver, { name: 'undefined-default' });
+
+      await cached();
+      vi.advanceTimersByTime(11_000);
+      await cached();
+
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it('should reject an empty list of storages', () => {
+      expect(() => cacheManager.cached(async () => 'value', { name: 'no-storage', storage: [] })).toThrow(CacheError);
+    });
+  });
+
+  describe('resolveKeys', () => {
+    it('should resolve one key per storage tier', async () => {
+      const keys = await cacheManager.resolveKeys({ name: 'keys', storage: ['default', 'secondary'] }, '1');
+
+      expect(keys).toHaveLength(2);
+      expect(keys[0]).toMatch(/^\/cache:functions:keys:/);
+      expect(keys[1]).toMatch(/^\/cache\/secondary:functions:keys:/);
+    });
+
+    it('should match the key a cached call actually writes', async () => {
+      const options = { name: 'key-match', maxAge: 60 };
+      await cacheManager.cached(async (id: string) => id, options)('1');
+
+      const [key] = await cacheManager.resolveKeys(options, '1');
+      await expect(storageManager.hasItem({ key })).resolves.toBe(true);
+    });
+  });
+
+  describe('invalidate', () => {
+    it('should drop the entry so the next call resolves again', async () => {
+      const resolver = vi.fn(async (id: string) => `user-${id}`);
+      const options = { name: 'invalidate', maxAge: 60 };
+      const cached = cacheManager.cached(resolver, options);
+
+      await cached('1');
+      await cacheManager.invalidate(options, '1');
+      await cached('1');
+
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it('should leave other entries untouched', async () => {
+      const resolver = vi.fn(async (id: string) => `user-${id}`);
+      const options = { name: 'invalidate-scoped', maxAge: 60 };
+      const cached = cacheManager.cached(resolver, options);
+
+      await cached('1');
+      await cached('2');
+      await cacheManager.invalidate(options, '1');
+      await cached('2');
+
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('expire', () => {
+    it('should mark the entry stale so the next call resolves again', async () => {
+      const resolver = vi.fn(async () => 'value');
+      const options = { name: 'expire', maxAge: 60 };
+      const cached = cacheManager.cached(resolver, options);
+
+      await cached();
+      await cacheManager.expire(options);
+      await cached();
+
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it('should serve the stale value while refreshing in the background with swr', async () => {
+      let counter = 0;
+      const resolver = vi.fn(async () => {
+        const next = ++counter;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return next;
+      });
+      const options = { name: 'expire-swr', maxAge: 60, swr: true, staleMaxAge: 600 };
+      const cached = cacheManager.cached(resolver, options);
+
+      await expect(cached()).resolves.toBe(1);
+      await cacheManager.expire(options);
+
+      // the stale value comes back without waiting for the refresh to finish
+      await expect(cached()).resolves.toBe(1);
+      expect(resolver).toHaveBeenCalledTimes(2);
+
+      // once the background refresh settles, the fresh value is served
+      await vi.waitFor(() => expect(cached()).resolves.toBe(2));
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/cache/test/CacheStorageAdapter.test.ts
+++ b/packages/cache/test/CacheStorageAdapter.test.ts
@@ -1,0 +1,231 @@
+import { Container, initializeContainer } from '@vercube/di';
+import { Logger } from '@vercube/logger';
+import { Storage, StorageManager } from '@vercube/storage';
+import { MemoryStorage } from '@vercube/storage/drivers/MemoryStorage';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cacheBaseForStorage, CacheError, CacheStorageAdapter, storageNameFromCacheKey } from '../src';
+
+describe('CacheStorageAdapter', () => {
+  let container: Container;
+  let logger: Logger;
+  let storageManager: StorageManager;
+
+  beforeEach(async () => {
+    container = new Container();
+    logger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger;
+
+    container.bindInstance(Container, container);
+    container.bindInstance(Logger, logger);
+    container.bind(StorageManager);
+    container.bind(Storage);
+    container.bind(MemoryStorage);
+    initializeContainer(container);
+
+    storageManager = container.get(StorageManager);
+    await storageManager.mount({ storage: MemoryStorage });
+    await storageManager.mount({ name: 'secondary', storage: MemoryStorage });
+  });
+
+  describe('cacheBaseForStorage', () => {
+    it('should use the bare prefix for the default storage', () => {
+      expect(cacheBaseForStorage()).toBe('/cache');
+      expect(cacheBaseForStorage('default')).toBe('/cache');
+    });
+
+    it('should append the storage name for named storages', () => {
+      expect(cacheBaseForStorage('redis')).toBe('/cache/redis');
+    });
+
+    it('should reject a storage name that would break key routing', () => {
+      // the base is read back by splitting on the first colon
+      expect(() => cacheBaseForStorage('a:b')).toThrow(CacheError);
+    });
+  });
+
+  describe('storageNameFromCacheKey', () => {
+    it('should resolve the default storage from a bare key', () => {
+      expect(storageNameFromCacheKey('/cache:functions:getUser:abc.json')).toBe('default');
+    });
+
+    it('should resolve a named storage', () => {
+      expect(storageNameFromCacheKey('/cache/redis:functions:getUser:abc.json')).toBe('redis');
+    });
+
+    it('should handle keys without a separator', () => {
+      expect(storageNameFromCacheKey('/cache/redis')).toBe('redis');
+      expect(storageNameFromCacheKey('/cache')).toBe('default');
+    });
+
+    it('should fall back to the default storage for an empty name segment', () => {
+      expect(storageNameFromCacheKey('/cache/:functions:getUser:abc.json')).toBe('default');
+    });
+  });
+
+  describe('routing', () => {
+    it('should route entries to the storage encoded in the key', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+
+      await adapter.set('/cache:functions:a:1.json', { value: 'default-storage' });
+      await adapter.set('/cache/secondary:functions:a:1.json', { value: 'secondary-storage' });
+
+      await expect(storageManager.getItem({ key: '/cache:functions:a:1.json' })).resolves.toEqual({ value: 'default-storage' });
+      await expect(storageManager.getItem({ storage: 'secondary', key: '/cache/secondary:functions:a:1.json' })).resolves.toEqual(
+        { value: 'secondary-storage' },
+      );
+    });
+
+    it('should read entries back from the storage encoded in the key', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+
+      await adapter.set('/cache/secondary:functions:a:1.json', { value: 42 });
+
+      await expect(adapter.get('/cache/secondary:functions:a:1.json')).resolves.toEqual({ value: 42 });
+      await expect(adapter.get('/cache:functions:a:1.json')).resolves.toBeNull();
+    });
+
+    it('should return null for missing entries', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+      await expect(adapter.get('/cache:functions:missing:1.json')).resolves.toBeNull();
+    });
+
+    it('should delete the entry when null is written', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+
+      await adapter.set('/cache:functions:a:1.json', { value: 1 });
+      await adapter.set('/cache:functions:a:1.json', null);
+
+      await expect(storageManager.hasItem({ key: '/cache:functions:a:1.json' })).resolves.toBe(false);
+      await expect(adapter.get('/cache:functions:a:1.json')).resolves.toBeNull();
+    });
+
+    it('should forward the ttl hint to the storage', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+      const storage = storageManager.getStorage()!;
+      const spy = vi.spyOn(storage, 'setItem');
+
+      await adapter.set('/cache:functions:a:1.json', { value: 1 }, { ttl: 60 });
+
+      expect(spy).toHaveBeenCalledWith('/cache:functions:a:1.json', { value: 1 }, { ttl: 60 });
+    });
+  });
+
+  describe('auto-mount', () => {
+    it('should mount an in-memory storage when the requested one is missing', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+
+      await adapter.set('/cache/nope:functions:a:1.json', { value: 'auto-mounted' });
+
+      // the entry lives in a regular storage, reachable through the StorageManager
+      expect(storageManager.getStorage('nope')).toBeInstanceOf(MemoryStorage);
+      await expect(storageManager.getItem({ storage: 'nope', key: '/cache/nope:functions:a:1.json' })).resolves.toEqual({
+        value: 'auto-mounted',
+      });
+      expect(logger.warn).toHaveBeenCalledOnce();
+    });
+
+    it('should mount a missing storage only once', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+
+      await adapter.set('/cache/nope:functions:a:1.json', { value: 1 });
+      await adapter.set('/cache/nope:functions:a:2.json', { value: 2 });
+
+      await expect(storageManager.size({ storage: 'nope' })).resolves.toBe(2);
+      expect(logger.warn).toHaveBeenCalledOnce();
+    });
+
+    it('should share one storage between concurrent auto-mounts', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+
+      await Promise.all([
+        adapter.set('/cache/nope:functions:a:1.json', { value: 1 }),
+        adapter.set('/cache/nope:functions:a:2.json', { value: 2 }),
+        adapter.set('/cache/nope:functions:a:3.json', { value: 3 }),
+      ]);
+
+      await expect(storageManager.size({ storage: 'nope' })).resolves.toBe(3);
+    });
+
+    it('should not touch storages that are already mounted', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+      const mounted = storageManager.getStorage('secondary');
+
+      await adapter.set('/cache/secondary:functions:a:1.json', { value: 1 });
+
+      expect(storageManager.getStorage('secondary')).toBe(mounted);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('should share a single in-flight mount between concurrent callers', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+      const realMount = storageManager.mount.bind(storageManager);
+
+      // a slow mount lets later callers reach the in-flight branch
+      const mount = vi.spyOn(storageManager, 'mount').mockImplementation(async (params) => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return realMount(params);
+      });
+
+      await Promise.all([
+        adapter.set('/cache/slow:functions:a:1.json', { value: 1 }),
+        adapter.set('/cache/slow:functions:a:2.json', { value: 2 }),
+        adapter.set('/cache/slow:functions:a:3.json', { value: 3 }),
+      ]);
+
+      expect(mount).toHaveBeenCalledOnce();
+      await expect(storageManager.size({ storage: 'slow' })).resolves.toBe(3);
+    });
+
+    it('should fail loudly when the fallback storage cannot be mounted', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+      vi.spyOn(storageManager, 'mount').mockResolvedValue(undefined);
+
+      await expect(adapter.get('/cache/nope:functions:a:1.json')).rejects.toThrow(CacheError);
+    });
+
+    it('should stay retryable after a failed mount', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+      const realMount = storageManager.mount.bind(storageManager);
+
+      const mount = vi.spyOn(storageManager, 'mount').mockRejectedValueOnce(new Error('transient failure'));
+
+      await expect(adapter.get('/cache/flaky:functions:a:1.json')).rejects.toThrow('transient failure');
+
+      // a failed mount must not poison the name for the rest of the process
+      mount.mockImplementation(realMount);
+
+      await adapter.set('/cache/flaky:functions:a:1.json', { value: 'recovered' });
+      await expect(adapter.get('/cache/flaky:functions:a:1.json')).resolves.toEqual({ value: 'recovered' });
+    });
+
+    it('should let a real storage mounted later take over from the fallback', async () => {
+      const adapter = container.resolve(CacheStorageAdapter);
+
+      await adapter.set('/cache/late:functions:a:1.json', { value: 'from-fallback' });
+
+      // replace the auto-mounted storage with a deliberately mounted one
+      await storageManager.mount({ name: 'late', storage: MemoryStorage });
+
+      await expect(adapter.get('/cache/late:functions:a:1.json')).resolves.toBeNull();
+
+      await adapter.set('/cache/late:functions:a:1.json', { value: 'from-real-storage' });
+      await expect(storageManager.getItem({ storage: 'late', key: '/cache/late:functions:a:1.json' })).resolves.toEqual({
+        value: 'from-real-storage',
+      });
+    });
+
+    it('should fail loudly when no StorageManager is registered', async () => {
+      const bare = new Container();
+      bare.bindInstance(Container, bare);
+      initializeContainer(bare);
+
+      const adapter = bare.resolve(CacheStorageAdapter);
+
+      await expect(adapter.get('/cache:functions:a:1.json')).rejects.toThrow(CacheError);
+    });
+  });
+});

--- a/packages/cache/test/Integration.test.ts
+++ b/packages/cache/test/Integration.test.ts
@@ -1,0 +1,103 @@
+import { Controller, createApp, Get, Param, QueryParam } from '@vercube/core';
+import { Logger } from '@vercube/logger';
+import { StorageManager } from '@vercube/storage';
+import { MemoryStorage } from '@vercube/storage/drivers/MemoryStorage';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Cache, CacheManager } from '../src';
+import type { App } from '@vercube/core';
+
+const handler = vi.fn();
+
+@Controller('/products')
+class ProductsController {
+  @Get('/:id')
+  @Cache({ maxAge: 60 })
+  public async getProduct(@Param('id') id: string): Promise<{ id: string; hits: number }> {
+    handler(id);
+    return { id, hits: handler.mock.calls.length };
+  }
+
+  @Get('/search/:id')
+  @Cache({ maxAge: 60 })
+  public async search(@Param('id') id: string, @QueryParam({ name: 'q' }) query: string): Promise<{ id: string; query: string }> {
+    handler(id, query);
+    return { id, query };
+  }
+}
+
+describe('@Cache in a live request pipeline', () => {
+  let app: App;
+  let storageManager: StorageManager;
+
+  // the app is built once: binding a controller class into a second container
+  // re-runs its route decorators and prefixes the path again (/products/products/:id)
+  beforeAll(async () => {
+    app = await createApp();
+
+    app.container.expand((container) => {
+      container.bindMock(Logger, { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+      container.bind(StorageManager);
+      container.bind(CacheManager);
+      container.bind(ProductsController);
+    });
+
+    storageManager = app.container.get(StorageManager);
+    await storageManager.mount({ name: 'cache', storage: MemoryStorage });
+    app.container.get(CacheManager).configure({ storage: 'cache' });
+  });
+
+  beforeEach(async () => {
+    handler.mockClear();
+    await storageManager.clear({ storage: 'cache' });
+  });
+
+  it('should serve a repeated request from the cache', async () => {
+    const first = await app.fetch(new Request('http://localhost/products/1'));
+    const second = await app.fetch(new Request('http://localhost/products/1'));
+
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toEqual({ id: '1', hits: 1 });
+    await expect(second.json()).resolves.toEqual({ id: '1', hits: 1 });
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('should key the cache by the resolved route parameters', async () => {
+    await app.fetch(new Request('http://localhost/products/1'));
+    await app.fetch(new Request('http://localhost/products/2'));
+    await app.fetch(new Request('http://localhost/products/1'));
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls.map(([id]) => id)).toEqual(['1', '2']);
+  });
+
+  it('should key the cache by query parameters too', async () => {
+    const first = await app.fetch(new Request('http://localhost/products/search/1?q=red'));
+    const second = await app.fetch(new Request('http://localhost/products/search/1?q=blue'));
+
+    await expect(first.json()).resolves.toEqual({ id: '1', query: 'red' });
+    await expect(second.json()).resolves.toEqual({ id: '1', query: 'blue' });
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('should keep the cached entries inside the mounted storage', async () => {
+    await app.fetch(new Request('http://localhost/products/1'));
+
+    const keys = await storageManager.getKeys({ storage: 'cache' });
+
+    expect(keys.some((key) => key.startsWith('/cache/cache:functions:ProductsController.getProduct:'))).toBe(true);
+    await expect(storageManager.size({ storage: 'cache' })).resolves.toBe(1);
+  });
+
+  it('should re-run the handler after the entry is invalidated', async () => {
+    await app.fetch(new Request('http://localhost/products/1'));
+
+    await app.container.get(CacheManager).invalidate({ name: 'ProductsController.getProduct', storage: 'cache' }, '1');
+
+    const response = await app.fetch(new Request('http://localhost/products/1'));
+
+    await expect(response.json()).resolves.toEqual({ id: '1', hits: 2 });
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/cache/test/Utils/Mock.mock.ts
+++ b/packages/cache/test/Utils/Mock.mock.ts
@@ -1,0 +1,43 @@
+import { Storage } from '@vercube/storage';
+
+/**
+ * Storage whose every operation rejects, used to prove that a broken cache
+ * backend never breaks the call it was supposed to speed up.
+ */
+export class BrokenStorage implements Storage {
+  public initialize(): void {
+    // nothing to initialize
+  }
+
+  public getItem<T = unknown>(): Promise<T | null> {
+    return Promise.reject(new Error('storage read failed'));
+  }
+
+  public getItems<T = unknown>(): Promise<T[]> {
+    return Promise.reject(new Error('storage read failed'));
+  }
+
+  public setItem(): Promise<void> {
+    return Promise.reject(new Error('storage write failed'));
+  }
+
+  public deleteItem(): Promise<void> {
+    return Promise.reject(new Error('storage delete failed'));
+  }
+
+  public hasItem(): Promise<boolean> {
+    return Promise.reject(new Error('storage read failed'));
+  }
+
+  public getKeys(): Promise<string[]> {
+    return Promise.reject(new Error('storage read failed'));
+  }
+
+  public clear(): Promise<void> {
+    return Promise.reject(new Error('storage clear failed'));
+  }
+
+  public size(): Promise<number> {
+    return Promise.reject(new Error('storage read failed'));
+  }
+}

--- a/packages/scan/src/Extract.ts
+++ b/packages/scan/src/Extract.ts
@@ -105,7 +105,7 @@ export function extractRoutes(code: string): RouteInfo[] {
  * regardless of whether it declares HTTP method routes.
  *
  * Unlike {@link extractRoutes} (which emits one entry per HTTP route method),
- * this returns one entry per controller class — so controllers that only carry
+ * this returns one entry per controller class - so controllers that only carry
  * non-HTTP handlers (e.g. WebSocket `@Message` methods) are still discovered for
  * binding into the DI container.
  *

--- a/packages/scan/src/Project.ts
+++ b/packages/scan/src/Project.ts
@@ -125,7 +125,7 @@ export interface ScanSourceOptions {
  * once.
  *
  * Unlike {@link scanProject}, this does not assume the Nitro convention of
- * dedicated `api`/`routes`/`services` subdirectories — decorated classes are
+ * dedicated `api`/`routes`/`services` subdirectories - decorated classes are
  * discovered wherever they live in the tree, which matches how Vercube apps are
  * typically organised. **Every** `@Controller` class is returned for binding
  * (not just those with HTTP routes), so WebSocket-only controllers are bound

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -83,9 +83,9 @@ node dist/index.mjs   # runs the built server
 
 ### `noExternal`
 
-Vercube keeps `@vercube/*` in a single module graph so class-reference DI tokens are not loaded twice. If a dependency imports `@vercube/core` from its published `dist` while your app resolves a different copy (common with pnpm), inject tokens such as `RequestContext` will not match — auth middleware writes to one instance, your services read from another.
+Vercube keeps `@vercube/*` in a single module graph so class-reference DI tokens are not loaded twice. If a dependency imports `@vercube/core` from its published `dist` while your app resolves a different copy (common with pnpm), inject tokens such as `RequestContext` will not match - auth middleware writes to one instance, your services read from another.
 
-The same patterns apply in **dev** (`resolve.noExternal`). In **production** the server bundle keeps `@vercube/*` and plugin packages as runtime imports — only app source (`@/…`) is inlined. Use **one** `@vercube/core` version across the app and dependencies (e.g. pnpm `overrides`), otherwise class-reference DI tokens such as `RequestContext` will not match between `@enp/auth` and your services.
+The same patterns apply in **dev** (`resolve.noExternal`). In **production** the server bundle keeps `@vercube/*` and plugin packages as runtime imports - only app source (`@/…`) is inlined. Use **one** `@vercube/core` version across the app and dependencies (e.g. pnpm `overrides`), otherwise class-reference DI tokens such as `RequestContext` will not match between `@enp/auth` and your services.
 
 Add packages that use Vercube DI tokens:
 

--- a/packages/vite/src/entry.ts
+++ b/packages/vite/src/entry.ts
@@ -46,7 +46,7 @@ export function generateServerEntry(ctx: VercubePluginContext): string {
 
   lines.push(...imports.values(), '');
 
-  // The setup hook runs before the app initializes — early enough to register
+  // The setup hook runs before the app initializes - early enough to register
   // plugins (`app.addPlugin`), mount storage, or bind interface→implementation
   // tokens that auto-discovery can't infer. It also wires the production static
   // server (see below). Auto-discovered controllers/services are bound

--- a/packages/vite/src/env.ts
+++ b/packages/vite/src/env.ts
@@ -10,7 +10,7 @@ import type { EnvironmentOptions } from 'vite';
 /**
  * Runtime dependencies of `@vercube/*` packages. When the framework is bundled
  * into `dist/index.mjs`, these imports surface at the bundle top level and must
- * be bundled too — pnpm does not hoist them to the app root.
+ * be bundled too - pnpm does not hoist them to the app root.
  */
 export const FRAMEWORK_RUNTIME_DEPS: (string | RegExp)[] = [
   /^srvx/,
@@ -92,7 +92,7 @@ export function createVercubeEnvironment(ctx: VercubePluginContext): Environment
 
   return {
     consumer: 'server',
-    // Class references are DI tokens — every module that shares a token (framework,
+    // Class references are DI tokens - every module that shares a token (framework,
     // app, plugins such as `@enp/auth`) must resolve to the same class identity.
     // Production bundles the full server dependency graph (see createProdExternal).
     resolve: ctx.dev ? { noExternal } : {},

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -24,7 +24,7 @@ export interface VercubePluginConfig {
   /**
    * Path (relative to `rootDir`) to a module whose default export is
    * `(app: App) => void | Promise<void>`. Runs after auto-discovered classes are
-   * bound but before the container queue is flushed — use it to mount storage,
+   * bound but before the container queue is flushed - use it to mount storage,
    * bind tokens, configure the logger, or register plugins that auto-discovery
    * cannot infer.
    */

--- a/packages/ws/src/Services/WebsocketService.ts
+++ b/packages/ws/src/Services/WebsocketService.ts
@@ -11,9 +11,9 @@ import type { Duplex } from 'node:stream';
 
 /**
  * A Node.js `(req, socket, head)` upgrade handler exposed on `globalThis` so
- * environments that drive the server through a raw Node HTTP upgrade event —
+ * environments that drive the server through a raw Node HTTP upgrade event -
  * notably the `@vercube/vite` dev server, where the app runs inside a worker
- * without its own listening `srvx` server — can hand WebSocket upgrades to the
+ * without its own listening `srvx` server - can hand WebSocket upgrades to the
  * same `crossws` hooks. Unused in normal deployments, where `srvx` handles the
  * upgrade natively.
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,12 @@ catalogs:
     nitro:
       specifier: 3.0.260610-beta
       version: 3.0.260610-beta
+    ocache:
+      specifier: 0.2.0
+      version: 0.2.0
+    ohash:
+      specifier: 2.0.11
+      version: 2.0.11
     pathe:
       specifier: 2.0.3
       version: 2.0.3
@@ -297,6 +303,28 @@ importers:
       '@vercube/logger':
         specifier: workspace:*
         version: link:../logger
+
+  packages/cache:
+    dependencies:
+      '@vercube/di':
+        specifier: workspace:*
+        version: link:../di
+      '@vercube/logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@vercube/storage':
+        specifier: workspace:*
+        version: link:../storage
+      ocache:
+        specifier: 'catalog:'
+        version: 0.2.0
+      ohash:
+        specifier: 'catalog:'
+        version: 2.0.11
+    devDependencies:
+      '@vercube/core':
+        specifier: workspace:*
+        version: link:../core
 
   packages/cli:
     dependencies:
@@ -3916,6 +3944,9 @@ packages:
   ocache@0.1.5:
     resolution: {integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==}
 
+  ocache@0.2.0:
+    resolution: {integrity: sha512-QE+SxXf/A8yR01rEOg2X5KwUe+mARHo1xQXl+iwLMzLIH06S5lBOZhhHQWp7T5etfFa8nOnRhvjGuo9YBCWwig==}
+
   ofetch@2.0.0-alpha.3:
     resolution: {integrity: sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==}
 
@@ -7532,6 +7563,10 @@ snapshots:
   obug@2.1.4: {}
 
   ocache@0.1.5:
+    dependencies:
+      ohash: 2.0.11
+
+  ocache@0.2.0:
     dependencies:
       ohash: 2.0.11
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,8 @@ catalog:
   consola: 3.4.2
   jiti: 2.7.0
   nitro: 3.0.260610-beta
+  ocache: 0.2.0
+  ohash: 2.0.11
   ufo: 1.6.4
   defu: 6.1.7
   env-runner: 0.1.16


### PR DESCRIPTION
Adds `@vercube/cache`, a package that turns any method into a cached one with a single decorator.

Caching is built on [ocache](https://ocache.unjs.io), the standalone extraction of Nitro's cache layer, which gives TTL, stale-while-revalidate, deduplication of concurrent calls and integrity-based invalidation for free. Everything is stored through `@vercube/storage`, so the cache owns no storage of its own: memory, S3 or any other driver backs it by mounting it.

## Usage

```ts
// src/container.ts
import { CacheManager } from '@vercube/cache';
import { StorageManager } from '@vercube/storage';
import { MemoryStorage } from '@vercube/storage/drivers/MemoryStorage';

export async function setupContainer(container: Container): Promise<void> {
  container.bind(StorageManager);
  container.bind(CacheManager);

  await container.get(StorageManager).mount({ name: 'cache', storage: MemoryStorage });
  container.get(CacheManager).configure({ storage: 'cache', maxAge: 60 });
}
```

```ts
// src/services/UsersService.ts
import { Cache } from '@vercube/cache';
import type { CacheTypes } from '@vercube/cache';

export class UsersService {
  @Cache({ maxAge: 300, swr: true, staleMaxAge: 900 })
  public async getUser(id: string): Promise<User> {
    return this.database.findUser(id);
  }

  public async updateUser(id: string, patch: Partial<User>): Promise<User> {
    const user = await this.database.updateUser(id, patch);

    // drop the cached entry for this user only
    await (this.getUser as CacheTypes.CachedMethod<[string], User>).invalidate(id);

    return user;
  }
}
```

The first call hits the database, the rest are served from storage, and simultaneous calls for the same `id` share a single round trip. A controller action is just a method, so decorating one caches the response keyed by its resolved route parameters.

## Notes

- Cache keys include an integrity hash of the method, so changing the implementation invalidates old entries instead of serving them.
- `swr` with `staleMaxAge` serves the stale value while a refresh runs in the background, which keeps the slow path off the request that triggered it.
- The package is additive: nothing caches until a method is decorated, and `CacheManager` is only needed when you use it.

Docs: [`docs/3.modules/9.cache`](https://vercube.dev/docs/modules/cache/overview).
