### PR TITLE
feat(telemetry)!: make @vercube/telemetry the only OpenTelemetry dependency

### DIFF
--- a/docs/3.modules/11.telemetry/0.overview.md
+++ b/docs/3.modules/11.telemetry/0.overview.md
@@ -21,10 +21,10 @@ By default it is on in development and off in production, because tracing every 
   ```
 ::
 
-Exporting to a collector additionally needs the OpenTelemetry SDK:
+That is the whole installation. This is the only package in the framework that depends on OpenTelemetry, and it ships the tracer and meter providers, the samplers and the in-memory test providers with it. Exporting to an OTLP collector is the one thing that needs more, because the exporter pulls a protobuf stack an application doing purely local tracing has no use for:
 
 ```bash
-$ pnpm add @opentelemetry/sdk-trace-node @opentelemetry/resources @opentelemetry/exporter-trace-otlp-http
+$ pnpm add @opentelemetry/exporter-trace-otlp-http
 ```
 
 ## Getting started
@@ -77,6 +77,8 @@ Alongside it:
 
 Instrumented modules add their own spans automatically. `@vercube/storage` traces each operation, `@vercube/cache` traces lookups and counts hits and misses, `@vercube/ws` traces messages, `@vercube/queue` traces published and processed jobs, and `@vercube/auth` records each authentication decision. They appear nested under the request that caused them without any wiring on your side.
 
+They all do it through `@vercube/telemetry/instrument`, which is public: see [Instrumentation](/docs/modules/telemetry/instrumentation) to do the same in a library of your own.
+
 ## Trace context
 
 Incoming `traceparent` and `tracestate` headers are read, so a request that arrives from another service continues the same trace. Going the other way, inject the current context into an outgoing call:
@@ -120,6 +122,8 @@ class InvoiceService {
 ```
 
 `span()` returns whatever your function returns, unchanged. A synchronous function stays synchronous.
+
+`Telemetry` is the token for application code. A reusable library is better off with [`@vercube/telemetry/instrument`](/docs/modules/telemetry/instrumentation), which needs no container.
 
 ## Logs
 

--- a/docs/3.modules/11.telemetry/1.api.md
+++ b/docs/3.modules/11.telemetry/1.api.md
@@ -146,7 +146,7 @@ Metric readers have to be registered before the provider is built, and instrumen
 
 The SDK classes and types a consumer needs to build a pipeline of its own: `NodeTracerProvider`, `BasicTracerProvider`, `MeterProvider`, `BatchSpanProcessor`, `SimpleSpanProcessor`, `InMemorySpanExporter`, `InMemoryMetricExporter`, `PeriodicExportingMetricReader`, `AggregationTemporality`, and the types `ReadableSpan`, `SpanProcessor`, `SpanExporter`, `IMetricReader`, `ResourceMetrics`, `Sampler`.
 
-The SDK's mutable span class is exported as `SdkSpan`, because it is a different thing from the API's `Span` interface and the two are not interchangeable. `SpanProcessor.onStart` receives an `SdkSpan`, `onEnd` receives a `ReadableSpan`.
+The SDK's mutable span class is re-exported as the type alias `SdkSpan`, because it is a different thing from the API's `Span` interface and the two are not interchangeable. It is `export type`, so it is available to `import type` and has no runtime binding. `SpanProcessor.onStart` receives an `SdkSpan`, `onEnd` receives a `ReadableSpan`.
 
 ```ts
 import { JsonTraceSerializer } from '@vercube/telemetry/otlp';

--- a/docs/3.modules/11.telemetry/1.api.md
+++ b/docs/3.modules/11.telemetry/1.api.md
@@ -1,7 +1,21 @@
 ---
 title: API
-description: The Telemetry token, the SDK entry point and the testing helpers
+description: The Telemetry token and the package's entry points
 ---
+
+The package publishes one entry point per job rather than a single barrel, so an import says what it reaches for and nothing pulls in the SDK by accident.
+
+| Import | What it is for |
+| --- | --- |
+| `@vercube/telemetry` | The `Telemetry` token and `TelemetryPlugin` |
+| `@vercube/telemetry/api` | The OpenTelemetry API |
+| `@vercube/telemetry/attributes` | Span and metric attribute keys |
+| `@vercube/telemetry/instrument` | Instrumenting a library of your own |
+| `@vercube/telemetry/sdk` | Tracer and meter provider wiring |
+| `@vercube/telemetry/otlp` | OTLP serializers and exporters |
+| `@vercube/telemetry/testing` | In-memory providers for tests |
+
+This is also the only package in the framework that depends on `@opentelemetry/*`. `@vercube/storage`, `@vercube/cache`, `@vercube/queue`, `@vercube/auth`, `@vercube/ws` and `@vercube/devtools` all instrument themselves through the subpaths above, so the OpenTelemetry version in use is decided in one place.
 
 ## Telemetry
 
@@ -69,9 +83,37 @@ const refunds = this.gTelemetry.meter.createCounter('billing.refunds');
 refunds.add(1, { 'billing.reason': reason });
 ```
 
+## @vercube/telemetry/api
+
+The OpenTelemetry API, re-exported in full. Use it to annotate spans without adding a dependency of your own.
+
+```ts
+import { SpanKind, trace } from '@vercube/telemetry/api';
+
+trace.getActiveSpan()?.setAttribute('invoice.id', id);
+```
+
+Anything `@opentelemetry/api` exports is available here, including the types: `Span`, `Context`, `Tracer`, `Meter`, `Attributes`, `Counter`, `Histogram`.
+
+## @vercube/telemetry/attributes
+
+The attribute keys the framework writes. The HTTP names follow the stable OpenTelemetry semantic conventions, the `vercube.*` names are this framework's own.
+
+```ts
+import { HTTP_ROUTE, VERCUBE_CONTROLLER } from '@vercube/telemetry/attributes';
+
+const route = span.attributes[HTTP_ROUTE];
+```
+
+Reading a span rather than producing one is what this is for, so it does not pull in the plugin.
+
+## @vercube/telemetry/instrument
+
+The toolkit for instrumenting a library. See [Instrumenting your own code](/docs/modules/telemetry/instrumentation).
+
 ## @vercube/telemetry/sdk
 
-Everything that needs the OpenTelemetry SDK lives behind this subpath, so the main entry stays API-only.
+Everything that needs the OpenTelemetry SDK lives behind this subpath, so the application entry stays free of it.
 
 ### startNodeTelemetry
 
@@ -99,6 +141,37 @@ ensureMeterProvider(options?: NodeTelemetryOptions): MeterProvider
 ```
 
 Metric readers have to be registered before the provider is built, and instruments have to be created after it exists. The OpenTelemetry metrics API has no proxy meter, so an instrument created before a provider is registered stays a no-op for the life of the process.
+
+### SDK re-exports
+
+The SDK classes and types a consumer needs to build a pipeline of its own: `NodeTracerProvider`, `BasicTracerProvider`, `MeterProvider`, `BatchSpanProcessor`, `SimpleSpanProcessor`, `InMemorySpanExporter`, `InMemoryMetricExporter`, `PeriodicExportingMetricReader`, `AggregationTemporality`, and the types `ReadableSpan`, `SpanProcessor`, `SpanExporter`, `IMetricReader`, `ResourceMetrics`, `Sampler`.
+
+The SDK's mutable span class is exported as `SdkSpan`, because it is a different thing from the API's `Span` interface and the two are not interchangeable. `SpanProcessor.onStart` receives an `SdkSpan`, `onEnd` receives a `ReadableSpan`.
+
+```ts
+import { JsonTraceSerializer } from '@vercube/telemetry/otlp';
+import type { ReadableSpan, SdkSpan, SpanProcessor } from '@vercube/telemetry/sdk';
+
+class MyProcessor implements SpanProcessor {
+  public onStart(_span: SdkSpan): void {}
+  public onEnd(span: ReadableSpan): void {
+    void JsonTraceSerializer.serializeRequest([span]);
+  }
+  public async forceFlush(): Promise<void> {}
+  public async shutdown(): Promise<void> {}
+}
+```
+
+## @vercube/telemetry/otlp
+
+`JsonTraceSerializer` and `JsonMetricsSerializer` turn collected signals into the OTLP/JSON wire format without sending them anywhere, which is what a consumer shipping its own transport needs. `@vercube/devtools` uses them to push spans over its own bus.
+
+```ts
+createOtlpTraceExporter(options: OtlpExporterOptions): Promise<SpanExporter>
+createOtlpMetricExporter(options: OtlpExporterOptions): Promise<PushMetricExporter>
+```
+
+Both take `{ endpoint, headers? }` and append the OTLP signal path for you. The exporter packages are optional peer dependencies loaded on demand, so a missing one produces a message telling you what to install rather than a module-resolution error at import time.
 
 ## @vercube/telemetry/testing
 

--- a/docs/3.modules/11.telemetry/2.instrumentation.md
+++ b/docs/3.modules/11.telemetry/2.instrumentation.md
@@ -50,10 +50,12 @@ A span parents itself on whatever is active. When the work continues in another 
 
 ```ts
 export function publish(job: Job): Promise<void> {
-  const headers: Record<string, string> = {};
-  instrument.inject(headers);
+  return instrument.span('acme.publish', { kind: SpanKind.PRODUCER }, () => {
+    const headers: Record<string, string> = {};
+    instrument.inject(headers);
 
-  return instrument.span('acme.publish', { kind: SpanKind.PRODUCER }, () => transport.send(job, headers));
+    return transport.send(job, headers);
+  });
 }
 
 export function consume(job: Job, headers: Record<string, string>): Promise<void> {
@@ -62,6 +64,8 @@ export function consume(job: Job, headers: Record<string, string>): Promise<void
 ```
 
 `inject` writes W3C trace context into a plain header record, `extract` reads it back into a context usable as a parent, and `spanFrom` takes that context instead of the active one. Without this the consumer starts a trace of its own and the two halves of the same operation can never be put back together.
+
+Call `inject` from **inside** the producer span, not before it. It writes whatever is active at that moment, so injecting first names the caller of `publish` as the parent and the producer span drops out of the chain. `@vercube/queue` builds its headers inside the publish span for this reason.
 
 Both use the globally registered propagator, so they do nothing until an application installs one.
 

--- a/docs/3.modules/11.telemetry/2.instrumentation.md
+++ b/docs/3.modules/11.telemetry/2.instrumentation.md
@@ -1,0 +1,94 @@
+---
+title: Instrumentation
+description: Producing spans and metrics from a library of your own
+---
+
+`@vercube/telemetry/instrument` is the toolkit the framework's own packages use to instrument themselves, and it is public for the same reason they need it. `@vercube/storage` traces every operation, `@vercube/cache` counts hits and misses, `@vercube/queue` carries trace context across a process boundary, and none of them depends on OpenTelemetry directly.
+
+Nothing on this subpath touches the HTTP layer, the plugin or the DI container. A library that wants to be traceable can import it without pulling the framework in.
+
+## createInstrument
+
+```ts
+import { createInstrument, SpanKind, ValueType } from '@vercube/telemetry/instrument';
+
+const instrument = createInstrument('acme-billing');
+```
+
+The argument is the instrumentation scope, conventionally your package name. It shows up on every span and instrument you produce, which is how a backend tells your spans apart from the framework's.
+
+Call it once at module level. Creating the toolkit creates nothing: the tracer is resolved on first span and the instruments on first use. That matters for metrics, because the OpenTelemetry metrics API has no proxy meter and an instrument created before a `MeterProvider` is registered stays a no-op for the life of the process.
+
+## Spans
+
+```ts
+export function charge(amount: number): Promise<Receipt> {
+  return instrument.span('billing.charge', { kind: SpanKind.CLIENT, attributes: { 'billing.amount': amount } }, () =>
+    gateway.charge(amount),
+  );
+}
+```
+
+`span` returns whatever your function returned, unchanged. A synchronous function stays synchronous, and the span ends when the work settles however it settles: a plain return, a synchronous throw, or a rejection. A failure records the exception, sets `error.type` and marks the span as failed.
+
+Server spans follow a different rule, and you do not want it here. A 4xx on a server span describes the caller, so the framework's request span is not marked failed by one. An error out of a storage driver carrying `status: 404` is a genuine failure of that operation, so `instrument.span` marks it.
+
+The callback receives the span, for anything you only learn while the work runs:
+
+```ts
+instrument.span('billing.charge', {}, (span) => {
+  const receipt = gateway.charge(amount);
+  span.setAttribute('billing.receipt', receipt.id);
+
+  return receipt;
+});
+```
+
+## Crossing a process boundary
+
+A span parents itself on whatever is active. When the work continues in another process, the parent has to travel with the message.
+
+```ts
+export function publish(job: Job): Promise<void> {
+  const headers: Record<string, string> = {};
+  instrument.inject(headers);
+
+  return instrument.span('acme.publish', { kind: SpanKind.PRODUCER }, () => transport.send(job, headers));
+}
+
+export function consume(job: Job, headers: Record<string, string>): Promise<void> {
+  return instrument.spanFrom('acme.process', { kind: SpanKind.CONSUMER }, instrument.extract(headers), () => run(job));
+}
+```
+
+`inject` writes W3C trace context into a plain header record, `extract` reads it back into a context usable as a parent, and `spanFrom` takes that context instead of the active one. Without this the consumer starts a trace of its own and the two halves of the same operation can never be put back together.
+
+Both use the globally registered propagator, so they do nothing until an application installs one.
+
+## Metrics
+
+```ts
+instrument
+  .counter('acme.billing.charges', {
+    description: 'Charges handed to the gateway.',
+    unit: '{charge}',
+    valueType: ValueType.INT,
+  })
+  .add(1, { 'billing.currency': currency });
+```
+
+`counter`, `upDownCounter` and `histogram` memoize by name, so calling them on every operation is what you are meant to do. The options are read the first time and ignored afterwards.
+
+Keep the attribute values bounded. One time series per customer id is how a metrics backend gets destroyed; put the unbounded value on the span instead, where it costs one attribute rather than one series.
+
+## The active span
+
+```ts
+instrument.activeSpan()?.addEvent('acme.decision', { 'acme.outcome': outcome });
+```
+
+Use this when the thing you are recording is part of an operation somebody else already opened a span for. `@vercube/auth` records its decision this way: the check is part of serving the request, and a span of its own for something that takes microseconds buys nothing.
+
+## Cost when nobody is collecting
+
+Every method is a no-op until the application registers a provider, so a library can instrument itself unconditionally. The OpenTelemetry API creates non-recording spans in that state, which is not free but is close to it, and with `telemetry: false` the framework's own instrumentation points are a single `null` check.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -26,10 +26,10 @@
     "build": "tsdown --config ../../tsdown.config.ts --config-loader=unrun"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.9.1",
     "@vercube/core": "workspace:*",
     "@vercube/di": "workspace:*",
-    "@vercube/logger": "workspace:*"
+    "@vercube/logger": "workspace:*",
+    "@vercube/telemetry": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/auth/src/Middleware/AuthMiddleware.ts
+++ b/packages/auth/src/Middleware/AuthMiddleware.ts
@@ -1,17 +1,21 @@
-import { metrics, trace, ValueType } from '@opentelemetry/api';
 import { UnauthorizedError } from '@vercube/core';
 import { Container, Inject, InjectOptional } from '@vercube/di';
 import { Logger } from '@vercube/logger';
+import { createInstrument, ValueType } from '@vercube/telemetry/instrument';
 import { AuthProvider } from '../Services/AuthProvider';
 import type { AuthTypes } from '../Types/AuthTypes';
-import type { Counter } from '@opentelemetry/api';
 import type { BaseMiddleware, MiddlewareOptions } from '@vercube/core';
 
-/** Instrumentation scope reported for auth signals. */
-const SCOPE = '@vercube/auth';
+/**
+ * Records auth signals.
+ *
+ * The toolkit comes from `@vercube/telemetry/instrument`, which is the only
+ * place in the framework that speaks to OpenTelemetry directly.
+ */
+const instrument = createInstrument('@vercube/auth');
 
-/** Lazily created outcome counter. */
-let outcomes: Counter | undefined;
+/** Attribute carrying how an authentication attempt ended. */
+const AUTH_OUTCOME = 'vercube.auth.outcome';
 
 /**
  * Records the outcome of one authentication attempt.
@@ -25,15 +29,15 @@ let outcomes: Counter | undefined;
  * @returns {void}
  */
 function recordOutcome(outcome: string): void {
-  trace.getActiveSpan()?.addEvent('auth.decision', { 'vercube.auth.outcome': outcome });
+  instrument.activeSpan()?.addEvent('auth.decision', { [AUTH_OUTCOME]: outcome });
 
-  outcomes ??= metrics.getMeter(SCOPE).createCounter('vercube.auth.decisions', {
-    description: 'Authentication decisions by outcome.',
-    unit: '{decision}',
-    valueType: ValueType.INT,
-  });
-
-  outcomes.add(1, { 'vercube.auth.outcome': outcome });
+  instrument
+    .counter('vercube.auth.decisions', {
+      description: 'Authentication decisions by outcome.',
+      unit: '{decision}',
+      valueType: ValueType.INT,
+    })
+    .add(1, { [AUTH_OUTCOME]: outcome });
 }
 
 /**

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -26,14 +26,13 @@
     "build": "tsdown --config ../../tsdown.config.ts --config-loader=unrun"
   },
   "devDependencies": {
-    "@vercube/core": "workspace:*",
-    "@vercube/telemetry": "workspace:*"
+    "@vercube/core": "workspace:*"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.9.1",
     "@vercube/di": "workspace:*",
     "@vercube/logger": "workspace:*",
     "@vercube/storage": "workspace:*",
+    "@vercube/telemetry": "workspace:*",
     "ocache": "catalog:",
     "ohash": "catalog:"
   },

--- a/packages/cache/src/Common/Instrument.ts
+++ b/packages/cache/src/Common/Instrument.ts
@@ -1,18 +1,19 @@
-import { context, metrics, SpanKind, SpanStatusCode, trace, ValueType } from '@opentelemetry/api';
-import type { Counter, Exception, Span } from '@opentelemetry/api';
+import { createInstrument, SpanKind, ValueType } from '@vercube/telemetry/instrument';
 
-/** Instrumentation scope reported for cache signals. */
-const SCOPE = '@vercube/cache';
+/**
+ * Traces and counts cache activity.
+ *
+ * The toolkit comes from `@vercube/telemetry/instrument`, which is the only
+ * place in the framework that speaks to OpenTelemetry directly, and it creates
+ * no instrument until one is actually used.
+ */
+const instrument = createInstrument('@vercube/cache');
 
 /** Attribute marking whether a lookup was served from the cache. */
 export const CACHE_HIT = 'vercube.cache.hit';
 
 /** Attribute carrying the cached function's name. */
 export const CACHE_NAME = 'vercube.cache.name';
-
-/** Lazily created counters, so no instrument exists until the cache is used. */
-let lookups: Counter | undefined;
-let misses: Counter | undefined;
 
 /**
  * Counts one cache lookup.
@@ -26,13 +27,13 @@ let misses: Counter | undefined;
  * @param name - The cached function's name
  */
 export function countLookup(name: string): void {
-  lookups ??= metrics.getMeter(SCOPE).createCounter('vercube.cache.lookups', {
-    description: 'Calls to a cached function.',
-    unit: '{lookup}',
-    valueType: ValueType.INT,
-  });
-
-  lookups.add(1, { [CACHE_NAME]: name });
+  instrument
+    .counter('vercube.cache.lookups', {
+      description: 'Calls to a cached function.',
+      unit: '{lookup}',
+      valueType: ValueType.INT,
+    })
+    .add(1, { [CACHE_NAME]: name });
 }
 
 /**
@@ -44,14 +45,15 @@ export function countLookup(name: string): void {
  * @param name - The cached function's name
  */
 export function countMiss(name: string): void {
-  misses ??= metrics.getMeter(SCOPE).createCounter('vercube.cache.misses', {
-    description: 'Cached function calls that had to resolve the value.',
-    unit: '{miss}',
-    valueType: ValueType.INT,
-  });
+  instrument
+    .counter('vercube.cache.misses', {
+      description: 'Cached function calls that had to resolve the value.',
+      unit: '{miss}',
+      valueType: ValueType.INT,
+    })
+    .add(1, { [CACHE_NAME]: name });
 
-  misses.add(1, { [CACHE_NAME]: name });
-  trace.getActiveSpan()?.setAttribute(CACHE_HIT, false);
+  instrument.activeSpan()?.setAttribute(CACHE_HIT, false);
 }
 
 /**
@@ -62,50 +64,5 @@ export function countMiss(name: string): void {
  * @returns Whatever the lookup returned
  */
 export function traceLookup<T>(name: string, fn: () => Promise<T>): Promise<T> {
-  const tracer = trace.getTracer(SCOPE);
-  const parent = context.active();
-  const span = tracer.startSpan(
-    `cache.${name}`,
-    { kind: SpanKind.CLIENT, attributes: { [CACHE_NAME]: name, [CACHE_HIT]: true } },
-    parent,
-  );
-
-  return context.with(trace.setSpan(parent, span), () => {
-    let pending: Promise<T>;
-
-    // `fn` is not necessarily an async function, so a synchronous throw would
-    // escape before `then` is attached and leave the span open forever.
-    try {
-      pending = fn();
-    } catch (error) {
-      fail(span, error);
-      span.end();
-
-      throw error;
-    }
-
-    return pending.then(
-      (value) => {
-        span.end();
-        return value;
-      },
-      (error: unknown) => {
-        fail(span, error);
-        span.end();
-        throw error;
-      },
-    );
-  });
-}
-
-/**
- * Records a failure on a span.
- *
- * @param span - The span to update
- * @param error - The thrown value
- */
-function fail(span: Span, error: unknown): void {
-  span.recordException(error as Exception);
-  span.setAttribute('error.type', error instanceof Error ? error.name : typeof error);
-  span.setStatus({ code: SpanStatusCode.ERROR, message: error instanceof Error ? error.message : String(error) });
+  return instrument.span(`cache.${name}`, { kind: SpanKind.CLIENT, attributes: { [CACHE_NAME]: name, [CACHE_HIT]: true } }, fn);
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -35,12 +35,6 @@
     "dev:ui": "vite --config ./ui/vite.config.ts"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.9.1",
-    "@opentelemetry/otlp-transformer": "0.222.0",
-    "@opentelemetry/resources": "2.11.0",
-    "@opentelemetry/sdk-metrics": "2.11.0",
-    "@opentelemetry/sdk-trace-base": "2.11.0",
-    "@opentelemetry/sdk-trace-node": "2.11.0",
     "@vercube/core": "workspace:*",
     "@vercube/di": "workspace:*",
     "@vercube/logger": "workspace:*",

--- a/packages/devtools/src/Services/SignalsDigest.ts
+++ b/packages/devtools/src/Services/SignalsDigest.ts
@@ -1,6 +1,12 @@
-import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
-import { HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, HTTP_ROUTE, URL_PATH, VERCUBE_DI_KEY } from '@vercube/telemetry';
-import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { SpanKind, SpanStatusCode } from '@vercube/telemetry/api';
+import {
+  HTTP_REQUEST_METHOD,
+  HTTP_RESPONSE_STATUS_CODE,
+  HTTP_ROUTE,
+  URL_PATH,
+  VERCUBE_DI_KEY,
+} from '@vercube/telemetry/attributes';
+import type { ReadableSpan } from '@vercube/telemetry/sdk';
 
 /** Aggregate view of recorded HTTP traffic. */
 export interface RequestStats {

--- a/packages/devtools/src/Telemetry/DevtoolsMetricPipeline.ts
+++ b/packages/devtools/src/Telemetry/DevtoolsMetricPipeline.ts
@@ -1,7 +1,7 @@
-import { JsonMetricsSerializer } from '@opentelemetry/otlp-transformer';
-import { AggregationTemporality, InMemoryMetricExporter, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { JsonMetricsSerializer } from '@vercube/telemetry/otlp';
+import { AggregationTemporality, InMemoryMetricExporter, PeriodicExportingMetricReader } from '@vercube/telemetry/sdk';
 import type { DevtoolsFrameBus } from '../Services/DevtoolsFrameBus';
-import type { IMetricReader, ResourceMetrics } from '@opentelemetry/sdk-metrics';
+import type { IMetricReader, ResourceMetrics } from '@vercube/telemetry/sdk';
 
 /** How often metrics are collected while a UI is connected, in milliseconds. */
 const COLLECT_INTERVAL_MS = 2000;

--- a/packages/devtools/src/Telemetry/DevtoolsSpanProcessor.ts
+++ b/packages/devtools/src/Telemetry/DevtoolsSpanProcessor.ts
@@ -1,7 +1,7 @@
-import { JsonTraceSerializer } from '@opentelemetry/otlp-transformer';
+import { JsonTraceSerializer } from '@vercube/telemetry/otlp';
 import type { DevtoolsFrameBus } from '../Services/DevtoolsFrameBus';
-import type { Context } from '@opentelemetry/api';
-import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import type { Context } from '@vercube/telemetry/api';
+import type { ReadableSpan, SdkSpan, SpanProcessor } from '@vercube/telemetry/sdk';
 
 /** How long finished spans are held before being flushed, in milliseconds. */
 const FLUSH_INTERVAL_MS = 100;
@@ -74,7 +74,7 @@ export class DevtoolsSpanProcessor implements SpanProcessor {
   }
 
   /** @inheritdoc */
-  public onStart(_span: Span, _parentContext: Context): void {
+  public onStart(_span: SdkSpan, _parentContext: Context): void {
     // Nothing to do: devtools only shows finished work.
   }
 

--- a/packages/devtools/src/Telemetry/DevtoolsTelemetry.ts
+++ b/packages/devtools/src/Telemetry/DevtoolsTelemetry.ts
@@ -1,4 +1,4 @@
-import { HTTP_ROUTE, URL_PATH } from '@vercube/telemetry';
+import { HTTP_ROUTE, URL_PATH } from '@vercube/telemetry/attributes';
 import {
   addMetricReader,
   addSpanProcessor,
@@ -12,8 +12,8 @@ import { DevtoolsLogDrain, DEVTOOLS_LOG_PLUGIN } from './DevtoolsLogDrain';
 import { DevtoolsMetricPipeline } from './DevtoolsMetricPipeline';
 import { DevtoolsSpanProcessor } from './DevtoolsSpanProcessor';
 import type { DevtoolsTypes } from '../Types/DevtoolsTypes';
-import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import type { Logger } from '@vercube/logger';
+import type { ReadableSpan } from '@vercube/telemetry/sdk';
 
 /**
  * Everything devtools listens to, in one place.

--- a/packages/devtools/test/Services/SignalsDigest.test.ts
+++ b/packages/devtools/test/Services/SignalsDigest.test.ts
@@ -1,4 +1,4 @@
-import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import { SpanKind, SpanStatusCode } from '@vercube/telemetry/api';
 import { describe, expect, it } from 'vitest';
 import {
   bootstrapHotspots,
@@ -9,7 +9,7 @@ import {
   serverSpans,
   statusOf,
 } from '../../src/Services/SignalsDigest';
-import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import type { ReadableSpan } from '@vercube/telemetry/sdk';
 
 /**
  * Builds a span shaped enough for the digest helpers.

--- a/packages/devtools/test/Telemetry/Pipeline.test.ts
+++ b/packages/devtools/test/Telemetry/Pipeline.test.ts
@@ -1,11 +1,11 @@
-import { SpanKind } from '@opentelemetry/api';
+import { SpanKind } from '@vercube/telemetry/api';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DevtoolsFrameBus } from '../../src/Services/DevtoolsFrameBus';
 import { DevtoolsLogDrain } from '../../src/Telemetry/DevtoolsLogDrain';
 import { DevtoolsMetricPipeline } from '../../src/Telemetry/DevtoolsMetricPipeline';
 import { DevtoolsSpanProcessor } from '../../src/Telemetry/DevtoolsSpanProcessor';
-import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import type { WideEvent } from '@vercube/logger';
+import type { ReadableSpan } from '@vercube/telemetry/sdk';
 
 /**
  * Builds a finished span shaped enough for the processor.

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -39,10 +39,10 @@
     "build": "tsdown --config tsdown.config.ts --config-loader=unrun"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.9.1",
     "@vercube/core": "workspace:*",
     "@vercube/di": "workspace:*",
-    "@vercube/logger": "workspace:*"
+    "@vercube/logger": "workspace:*",
+    "@vercube/telemetry": "workspace:*"
   },
   "optionalDependencies": {
     "amqplib": "2.0.1",
@@ -51,8 +51,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "devDependencies": {
-    "@vercube/telemetry": "workspace:*"
   }
 }

--- a/packages/queue/src/Common/Instrument.ts
+++ b/packages/queue/src/Common/Instrument.ts
@@ -1,8 +1,14 @@
-import { context, metrics, propagation, ROOT_CONTEXT, SpanKind, SpanStatusCode, trace, ValueType } from '@opentelemetry/api';
-import type { Counter, Exception, Span } from '@opentelemetry/api';
+import { createInstrument, SpanKind, ValueType } from '@vercube/telemetry/instrument';
+import type { Context } from '@vercube/telemetry/instrument';
 
-/** Instrumentation scope reported for queue signals. */
-const SCOPE = '@vercube/queue';
+/**
+ * Traces and counts queue activity.
+ *
+ * The toolkit comes from `@vercube/telemetry/instrument`, which is the only
+ * place in the framework that speaks to OpenTelemetry directly, and it creates
+ * no instrument until one is actually used.
+ */
+const instrument = createInstrument('@vercube/queue');
 
 /** Attribute naming the transport a job travelled through. */
 export const QUEUE_STRATEGY = 'vercube.queue.strategy';
@@ -16,9 +22,8 @@ export const QUEUE_JOB = 'vercube.queue.job';
 /** Attribute carrying the attempt number. */
 export const QUEUE_ATTEMPT = 'vercube.queue.attempt';
 
-/** Lazily created counters, so no instrument exists until the queue is used. */
-let published: Counter | undefined;
-let processed: Counter | undefined;
+/** Attribute carrying how an attempt ended. */
+const QUEUE_OUTCOME = 'vercube.queue.outcome';
 
 /**
  * Writes the active trace context into a job's headers.
@@ -33,7 +38,7 @@ let processed: Counter | undefined;
  * @param headers - Headers the job will carry
  */
 export function injectTraceContext(headers: Record<string, string>): void {
-  propagation.inject(context.active(), headers);
+  instrument.inject(headers);
 }
 
 /**
@@ -42,8 +47,8 @@ export function injectTraceContext(headers: Record<string, string>): void {
  * @param headers - Headers the job arrived with
  * @returns A context carrying the publishing span as parent
  */
-export function extractTraceContext(headers: Record<string, string> | undefined): ReturnType<typeof propagation.extract> {
-  return propagation.extract(ROOT_CONTEXT, headers ?? {});
+export function extractTraceContext(headers: Record<string, string> | undefined): Context {
+  return instrument.extract(headers);
 }
 
 /**
@@ -59,8 +64,13 @@ export function tracePublish<T>(
   count: number,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const parent = context.active();
-  const span = trace.getTracer(SCOPE).startSpan(
+  const published = instrument.counter('vercube.queue.published', {
+    description: 'Jobs handed to a transport.',
+    unit: '{job}',
+    valueType: ValueType.INT,
+  });
+
+  const publish = instrument.span(
     `queue.publish ${target.queue}`,
     {
       kind: SpanKind.PRODUCER,
@@ -71,19 +81,13 @@ export function tracePublish<T>(
         'vercube.queue.batch': count,
       },
     },
-    parent,
+    fn,
   );
-
-  published ??= metrics.getMeter(SCOPE).createCounter('vercube.queue.published', {
-    description: 'Jobs handed to a transport.',
-    unit: '{job}',
-    valueType: ValueType.INT,
-  });
 
   // Counted once the transport took them, so this keeps agreeing with the
   // manager's own `published` counter instead of drifting on every rejection.
-  return settle(span, parent, fn).then((value) => {
-    published?.add(count, { [QUEUE_NAME]: target.queue, [QUEUE_JOB]: target.job });
+  return publish.then((value) => {
+    published.add(count, { [QUEUE_NAME]: target.queue, [QUEUE_JOB]: target.job });
 
     return value;
   });
@@ -106,8 +110,7 @@ export function traceProcess<T>(
   headers: Record<string, string> | undefined,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const parent = extractTraceContext(headers);
-  const span = trace.getTracer(SCOPE).startSpan(
+  return instrument.spanFrom(
     `queue.process ${target.queue}.${target.job}`,
     {
       kind: SpanKind.CONSUMER,
@@ -118,10 +121,9 @@ export function traceProcess<T>(
         [QUEUE_ATTEMPT]: target.attempt,
       },
     },
-    parent,
+    extractTraceContext(headers),
+    fn,
   );
-
-  return settle(span, parent, fn);
 }
 
 /**
@@ -131,59 +133,13 @@ export function traceProcess<T>(
  * @param outcome - How the attempt ended
  */
 export function countOutcome(target: { queue: string; job: string }, outcome: string): void {
-  processed ??= metrics.getMeter(SCOPE).createCounter('vercube.queue.processed', {
-    description: 'Job attempts by outcome.',
-    unit: '{attempt}',
-    valueType: ValueType.INT,
-  });
+  instrument
+    .counter('vercube.queue.processed', {
+      description: 'Job attempts by outcome.',
+      unit: '{attempt}',
+      valueType: ValueType.INT,
+    })
+    .add(1, { [QUEUE_NAME]: target.queue, [QUEUE_JOB]: target.job, [QUEUE_OUTCOME]: outcome });
 
-  processed.add(1, { [QUEUE_NAME]: target.queue, [QUEUE_JOB]: target.job, 'vercube.queue.outcome': outcome });
-  trace.getActiveSpan()?.setAttribute('vercube.queue.outcome', outcome);
-}
-
-/**
- * Runs the traced work inside the span and ends it once it settles.
- *
- * @param span - The span covering the work
- * @param parent - Context the span was started from
- * @param fn - The work
- * @returns Whatever the work returned
- */
-function settle<T>(span: Span, parent: ReturnType<typeof context.active>, fn: () => Promise<T>): Promise<T> {
-  return context.with(trace.setSpan(parent, span), () => {
-    let pending: Promise<T>;
-
-    try {
-      pending = fn();
-    } catch (error) {
-      fail(span, error);
-      span.end();
-
-      throw error;
-    }
-
-    return pending.then(
-      (value) => {
-        span.end();
-        return value;
-      },
-      (error: unknown) => {
-        fail(span, error);
-        span.end();
-        throw error;
-      },
-    );
-  });
-}
-
-/**
- * Records a failure on a span.
- *
- * @param span - The span to update
- * @param error - The thrown value
- */
-function fail(span: Span, error: unknown): void {
-  span.recordException(error as Exception);
-  span.setAttribute('error.type', error instanceof Error ? error.name : typeof error);
-  span.setStatus({ code: SpanStatusCode.ERROR, message: error instanceof Error ? error.message : String(error) });
+  instrument.activeSpan()?.setAttribute(QUEUE_OUTCOME, outcome);
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -28,17 +28,14 @@
     "build": "tsdown --config tsdown.config.ts --config-loader=unrun"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.9.1",
     "@vercube/di": "workspace:*",
-    "@vercube/logger": "workspace:*"
+    "@vercube/logger": "workspace:*",
+    "@vercube/telemetry": "workspace:*"
   },
   "optionalDependencies": {
     "@aws-sdk/client-s3": "3.1127.0"
   },
   "publishConfig": {
     "access": "public"
-  },
-  "devDependencies": {
-    "@vercube/telemetry": "workspace:*"
   }
 }

--- a/packages/storage/src/Common/Instrument.ts
+++ b/packages/storage/src/Common/Instrument.ts
@@ -1,18 +1,17 @@
-import { context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
-import type { Exception, Span } from '@opentelemetry/api';
-
-/**
- * Instrumentation scope reported for storage spans.
- */
-const SCOPE = '@vercube/storage';
+import { createInstrument, SpanKind } from '@vercube/telemetry/instrument';
 
 /**
  * Traces storage operations.
  *
- * This depends on `@opentelemetry/api` and nothing else: it is the contract an
- * instrumented library is supposed to speak, it is a no-op until an application
- * registers a tracer provider, and it keeps `@vercube/storage` usable without
- * the rest of the framework.
+ * The toolkit comes from `@vercube/telemetry/instrument`, which is the only
+ * place in the framework that speaks to OpenTelemetry directly. It is a no-op
+ * until an application registers a tracer provider, so this costs nothing in a
+ * process that is not collecting telemetry.
+ */
+const instrument = createInstrument('@vercube/storage');
+
+/**
+ * Traces one storage operation.
  *
  * @param name - Operation name, e.g. `storage.getItem`
  * @param attributes - Attributes describing the operation
@@ -24,33 +23,5 @@ export function traceOperation<T>(
   attributes: Record<string, string | number | boolean | undefined>,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const tracer = trace.getTracer(SCOPE);
-  const parent = context.active();
-  const span = tracer.startSpan(name, { kind: SpanKind.CLIENT, attributes }, parent);
-
-  return context.with(trace.setSpan(parent, span), () =>
-    fn().then(
-      (value) => {
-        span.end();
-        return value;
-      },
-      (error: unknown) => {
-        fail(span, error);
-        span.end();
-        throw error;
-      },
-    ),
-  );
-}
-
-/**
- * Records a failure on a span.
- *
- * @param span - The span to update
- * @param error - The thrown value
- */
-function fail(span: Span, error: unknown): void {
-  span.recordException(error as Exception);
-  span.setAttribute('error.type', error instanceof Error ? error.name : typeof error);
-  span.setStatus({ code: SpanStatusCode.ERROR, message: error instanceof Error ? error.message : String(error) });
+  return instrument.span(name, { kind: SpanKind.CLIENT, attributes }, fn);
 }

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -23,7 +23,7 @@
 - **A span per request** - route template, controller, handler and the stable HTTP semantic conventions
 - **W3C trace context** - `traceparent` read on the way in, injectable on the way out
 - **One AsyncLocalStorage** - trace context rides in the request context Vercube already opens, not a second frame
-- **API only by default** - `@opentelemetry/api` is the single dependency; the SDK, exporters and samplers are optional
+- **One OpenTelemetry dependency** - this is the only package in the framework that declares one; everything else reaches OpenTelemetry through a subpath here
 - **Zero cost when off** - core sees a `null` check, and the allocation-free route fast path stays synchronous
 
 ## 📦 Installation
@@ -32,10 +32,10 @@
 pnpm add @vercube/telemetry
 ```
 
-Exporting to a collector additionally needs the OpenTelemetry SDK:
+That is the whole installation: the tracer and meter providers, the samplers and the in-memory test providers all ship with it. Exporting to an OTLP collector is the one thing that needs more, because the exporter pulls a protobuf stack an application doing local tracing has no use for:
 
 ```bash
-pnpm add @opentelemetry/sdk-trace-node @opentelemetry/resources @opentelemetry/exporter-trace-otlp-http
+pnpm add @opentelemetry/exporter-trace-otlp-http
 ```
 
 ## 📖 Usage

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -20,6 +20,26 @@
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
+    "./api": {
+      "types": "./dist/Api.d.mts",
+      "import": "./dist/Api.mjs",
+      "default": "./dist/Api.mjs"
+    },
+    "./attributes": {
+      "types": "./dist/Attributes.d.mts",
+      "import": "./dist/Attributes.mjs",
+      "default": "./dist/Attributes.mjs"
+    },
+    "./instrument": {
+      "types": "./dist/Instrument.d.mts",
+      "import": "./dist/Instrument.mjs",
+      "default": "./dist/Instrument.mjs"
+    },
+    "./otlp": {
+      "types": "./dist/Otlp.d.mts",
+      "import": "./dist/Otlp.mjs",
+      "default": "./dist/Otlp.mjs"
+    },
     "./sdk": {
       "types": "./dist/Sdk.d.mts",
       "import": "./dist/Sdk.mjs",
@@ -49,17 +69,18 @@
   },
   "dependencies": {
     "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/otlp-transformer": "0.222.0",
+    "@opentelemetry/resources": "2.11.0",
+    "@opentelemetry/sdk-metrics": "2.11.0",
+    "@opentelemetry/sdk-trace-base": "2.11.0",
+    "@opentelemetry/sdk-trace-node": "2.11.0",
     "@vercube/core": "workspace:*",
     "@vercube/di": "workspace:*",
     "@vercube/logger": "workspace:*"
   },
   "peerDependencies": {
     "@opentelemetry/exporter-metrics-otlp-http": "^0.222.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.222.0",
-    "@opentelemetry/resources": "^2.11.0",
-    "@opentelemetry/sdk-metrics": "^2.11.0",
-    "@opentelemetry/sdk-trace-base": "^2.11.0",
-    "@opentelemetry/sdk-trace-node": "^2.11.0"
+    "@opentelemetry/exporter-trace-otlp-http": "^0.222.0"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/exporter-metrics-otlp-http": {
@@ -67,28 +88,13 @@
     },
     "@opentelemetry/exporter-trace-otlp-http": {
       "optional": true
-    },
-    "@opentelemetry/resources": {
-      "optional": true
-    },
-    "@opentelemetry/sdk-metrics": {
-      "optional": true
-    },
-    "@opentelemetry/sdk-trace-base": {
-      "optional": true
-    },
-    "@opentelemetry/sdk-trace-node": {
-      "optional": true
     }
   },
   "publishConfig": {
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/exporter-trace-otlp-http": "0.222.0",
-    "@opentelemetry/resources": "2.11.0",
-    "@opentelemetry/sdk-metrics": "2.11.0",
-    "@opentelemetry/sdk-trace-base": "2.11.0",
-    "@opentelemetry/sdk-trace-node": "2.11.0"
+    "@opentelemetry/exporter-metrics-otlp-http": "0.222.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.222.0"
   }
 }

--- a/packages/telemetry/src/Api.ts
+++ b/packages/telemetry/src/Api.ts
@@ -1,0 +1,18 @@
+/**
+ * The OpenTelemetry API, re-exported in full.
+ *
+ * This subpath is the framework's single point of contact with
+ * `@opentelemetry/api`: every other `@vercube/*` package imports the API from
+ * here rather than depending on it directly, so the version in use is decided
+ * in exactly one `package.json`.
+ *
+ * ```ts
+ * import { SpanKind, trace } from '@vercube/telemetry/api';
+ * ```
+ *
+ * Re-exported wholesale rather than as a curated list. A hand-picked slice is a
+ * permanent maintenance debt - the previous one was already missing
+ * `Exception`, `createTraceState` and `isSpanContextValid` - and the API package
+ * is small, tree-shakeable and a no-op until a provider is registered.
+ */
+export * from '@opentelemetry/api';

--- a/packages/telemetry/src/Attributes.ts
+++ b/packages/telemetry/src/Attributes.ts
@@ -1,0 +1,13 @@
+/**
+ * Span and metric attribute keys.
+ *
+ * The HTTP names follow the stable OpenTelemetry semantic conventions; the
+ * `vercube.*` names are this framework's own. Kept on a subpath of their own so
+ * a consumer that only reads spans - `@vercube/devtools` does - does not have
+ * to pull in the plugin to name an attribute.
+ *
+ * ```ts
+ * import { HTTP_ROUTE, URL_PATH } from '@vercube/telemetry/attributes';
+ * ```
+ */
+export * from './Common/Attributes';

--- a/packages/telemetry/src/Common/SpanUtils.ts
+++ b/packages/telemetry/src/Common/SpanUtils.ts
@@ -109,23 +109,46 @@ export function completeSpan(span: Span, value: unknown): void {
 }
 
 /**
- * Records a thrown value on a span and marks the span as failed.
+ * Records a thrown value on a span and marks the span as failed, whatever the
+ * error looks like.
+ *
+ * This is the variant for spans that carry no HTTP status semantics - the
+ * `CLIENT`, `PRODUCER` and `CONSUMER` spans an instrumented package produces.
+ * `failSpan` is the server-span variant and deliberately behaves differently;
+ * see the comment there before merging the two.
+ *
+ * @param span - The span to update
+ * @param error - The thrown value
+ */
+export function recordFailure(span: Span, error: unknown): void {
+  span.recordException(error as Exception);
+  span.setAttribute(ERROR_TYPE, errorType(error));
+  span.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage(error) });
+}
+
+/**
+ * Records a thrown value on a *server* span and marks it failed only when the
+ * failure is the server's own.
  *
  * @param span - The span to update
  * @param error - The thrown value
  */
 export function failSpan(span: Span, error: unknown): void {
-  span.recordException(error as Exception);
-  span.setAttribute(ERROR_TYPE, errorType(error));
-
   // A 404 or a 401 describes the request, not a fault of the server, and the
   // HTTP semantic conventions say a server span must only be ERROR for 5xx.
   // Marking them failed turns every probe for a missing page into an incident.
+  //
+  // A storage or cache span must NOT inherit this rule: an S3 error carrying
+  // `status: 404` is a genuine failure of that operation. Those call sites use
+  // `recordFailure` instead, which is why the two exist side by side.
   if (httpStatusOf(error) < SERVER_ERROR_STATUS) {
+    span.recordException(error as Exception);
+    span.setAttribute(ERROR_TYPE, errorType(error));
+
     return;
   }
 
-  span.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage(error) });
+  recordFailure(span, error);
 }
 
 /**
@@ -179,6 +202,6 @@ export function errorMessage(error: unknown): string {
  * @param value - The value to test
  * @returns True for thenables
  */
-function isPromiseLike(value: unknown): boolean {
+export function isPromiseLike(value: unknown): boolean {
   return value instanceof Promise || typeof (value as PromiseLike<unknown> | undefined)?.then === 'function';
 }

--- a/packages/telemetry/src/Instrument.ts
+++ b/packages/telemetry/src/Instrument.ts
@@ -1,0 +1,46 @@
+/**
+ * The toolkit for writing an instrumented package.
+ *
+ * Everything a `@vercube/*` package needs to produce spans and metrics, so it
+ * never has to depend on `@opentelemetry/api` itself. It is also the public
+ * contract for an application's own instrumented libraries: nothing here
+ * touches the HTTP layer, the plugin or the DI container, so importing it does
+ * not drag the framework into a library that only wants to be traceable.
+ *
+ * ```ts
+ * import { createInstrument, SpanKind, ValueType } from '@vercube/telemetry/instrument';
+ *
+ * const instrument = createInstrument('acme-billing');
+ *
+ * export function charge(amount: number): Promise<Receipt> {
+ *   instrument.counter('acme.billing.charges', { valueType: ValueType.INT }).add(1);
+ *
+ *   return instrument.span('billing.charge', { kind: SpanKind.CLIENT }, () => gateway.charge(amount));
+ * }
+ * ```
+ */
+export { createInstrument } from './Instrument/Factory';
+export type { Instrument } from './Instrument/Factory';
+
+/**
+ * Marks a span failed whatever the error looks like. `Instrument.span` applies
+ * it for you; call it directly only when you own the span.
+ */
+export { errorMessage, errorType, recordFailure } from './Common/SpanUtils';
+
+// The slice of the OpenTelemetry API an instrumented package actually needs, so
+// one import covers the whole job. The full API is on `@vercube/telemetry/api`.
+export { SpanKind, SpanStatusCode, ValueType } from '@opentelemetry/api';
+export type {
+  Attributes,
+  Context,
+  Counter,
+  Exception,
+  Histogram,
+  Link,
+  MetricOptions,
+  Span,
+  SpanContext,
+  SpanOptions,
+  UpDownCounter,
+} from '@opentelemetry/api';

--- a/packages/telemetry/src/Instrument/Factory.ts
+++ b/packages/telemetry/src/Instrument/Factory.ts
@@ -1,0 +1,218 @@
+import { context, metrics, propagation, ROOT_CONTEXT, trace } from '@opentelemetry/api';
+import { isPromiseLike, recordFailure } from '../Common/SpanUtils';
+import type { Context, Counter, Histogram, MetricOptions, Span, SpanOptions, Tracer, UpDownCounter } from '@opentelemetry/api';
+
+/**
+ * The instrumentation toolkit an instrumented package works against.
+ *
+ * Every method is a no-op until the application registers a provider, which is
+ * what lets a package produce telemetry unconditionally.
+ */
+export interface Instrument {
+  /**
+   * Runs `fn` in a new span parented on the active context.
+   *
+   * The result is returned unchanged, so wrapping synchronous code does not
+   * make it asynchronous. A synchronous throw, a rejection and a plain return
+   * all end the span.
+   *
+   * @param name - Span name
+   * @param options - Span kind, attributes and links
+   * @param fn - The work to trace
+   * @returns Whatever `fn` returned
+   */
+  span<T>(name: string, options: SpanOptions, fn: (span: Span) => T): T;
+
+  /**
+   * Same as {@link Instrument.span}, parented on an explicit context.
+   *
+   * This is how a background job continues the trace of the request that
+   * queued it: the parent comes from {@link Instrument.extract} rather than
+   * from whatever happens to be active in the worker.
+   *
+   * @param name - Span name
+   * @param options - Span kind, attributes and links
+   * @param parent - Context the span is a child of
+   * @param fn - The work to trace
+   * @returns Whatever `fn` returned
+   */
+  spanFrom<T>(name: string, options: SpanOptions, parent: Context, fn: (span: Span) => T): T;
+
+  /**
+   * A monotonic counter, created on first use and memoized by name.
+   *
+   * @param name - Instrument name
+   * @param options - Description, unit and value type
+   * @returns The counter
+   */
+  counter(name: string, options?: MetricOptions): Counter;
+
+  /**
+   * A counter that can go down, created on first use and memoized by name.
+   *
+   * @param name - Instrument name
+   * @param options - Description, unit and value type
+   * @returns The counter
+   */
+  upDownCounter(name: string, options?: MetricOptions): UpDownCounter;
+
+  /**
+   * A histogram, created on first use and memoized by name.
+   *
+   * @param name - Instrument name
+   * @param options - Description, unit and value type
+   * @returns The histogram
+   */
+  histogram(name: string, options?: MetricOptions): Histogram;
+
+  /** The span active on this async execution path, if any. */
+  activeSpan(): Span | undefined;
+
+  /**
+   * Writes W3C trace context for the active span into a carrier.
+   *
+   * @param carrier - Header record to write into
+   */
+  inject(carrier: Record<string, string>): void;
+
+  /**
+   * Reads W3C trace context out of a carrier into a context usable as a parent.
+   *
+   * @param carrier - Header record the message arrived with
+   * @returns A context carrying the remote parent
+   */
+  extract(carrier: Record<string, string> | undefined): Context;
+}
+
+/**
+ * Builds the instrumentation toolkit for one instrumentation scope.
+ *
+ * A `@vercube/*` package calls this once at module level and uses the result
+ * everywhere it produces telemetry:
+ *
+ * ```ts
+ * import { createInstrument, SpanKind } from '@vercube/telemetry/instrument';
+ *
+ * const instrument = createInstrument('@vercube/storage');
+ *
+ * export function traceOperation<T>(name: string, attributes: Attributes, fn: () => Promise<T>): Promise<T> {
+ *   return instrument.span(name, { kind: SpanKind.CLIENT, attributes }, fn);
+ * }
+ * ```
+ *
+ * Creating the toolkit creates nothing: the tracer is resolved lazily and the
+ * instruments only on first use. That matters for metrics, because the
+ * OpenTelemetry metrics API has no proxy meter and an instrument created before
+ * a `MeterProvider` is registered stays a no-op for the life of the process.
+ *
+ * @param scope - Instrumentation scope, conventionally the package name
+ * @returns The toolkit bound to that scope
+ */
+export function createInstrument(scope: string): Instrument {
+  // Safe to memoize: `trace.getTracer` hands back a `ProxyTracer` that
+  // delegates on every call, so a tracer taken before the provider exists
+  // starts recording the moment one is registered. Meters have no such proxy,
+  // which is why they are not cached the same way.
+  let tracer: Tracer | undefined;
+
+  const counters = new Map<string, Counter>();
+  const upDownCounters = new Map<string, UpDownCounter>();
+  const histograms = new Map<string, Histogram>();
+
+  /**
+   * Starts a span, runs the work inside it and ends it once the work settles.
+   *
+   * @param name - Span name
+   * @param options - Span kind, attributes and links
+   * @param parent - Context the span is a child of
+   * @param fn - The work to trace
+   * @returns Whatever the work returned
+   */
+  function run<T>(name: string, options: SpanOptions, parent: Context, fn: (span: Span) => T): T {
+    tracer ??= trace.getTracer(scope);
+
+    const span = tracer.startSpan(name, options, parent);
+
+    return context.with(trace.setSpan(parent, span), () => {
+      let result: T;
+
+      // `fn` is not necessarily an async function, so a synchronous throw would
+      // escape before `then` is attached and leave the span open forever.
+      try {
+        result = fn(span);
+      } catch (error) {
+        recordFailure(span, error);
+        span.end();
+
+        throw error;
+      }
+
+      if (!isPromiseLike(result)) {
+        span.end();
+
+        return result;
+      }
+
+      return (result as PromiseLike<unknown>).then(
+        (value: unknown) => {
+          span.end();
+
+          return value;
+        },
+        (error: unknown) => {
+          recordFailure(span, error);
+          span.end();
+
+          throw error;
+        },
+      ) as T;
+    });
+  }
+
+  return {
+    span: (name, options, fn) => run(name, options, context.active(), fn),
+
+    spanFrom: (name, options, parent, fn) => run(name, options, parent, fn),
+
+    counter(name, options) {
+      let instrument = counters.get(name);
+
+      if (!instrument) {
+        instrument = metrics.getMeter(scope).createCounter(name, options);
+        counters.set(name, instrument);
+      }
+
+      return instrument;
+    },
+
+    upDownCounter(name, options) {
+      let instrument = upDownCounters.get(name);
+
+      if (!instrument) {
+        instrument = metrics.getMeter(scope).createUpDownCounter(name, options);
+        upDownCounters.set(name, instrument);
+      }
+
+      return instrument;
+    },
+
+    histogram(name, options) {
+      let instrument = histograms.get(name);
+
+      if (!instrument) {
+        instrument = metrics.getMeter(scope).createHistogram(name, options);
+        histograms.set(name, instrument);
+      }
+
+      return instrument;
+    },
+
+    activeSpan: () => trace.getActiveSpan(),
+
+    inject(carrier) {
+      propagation.inject(context.active(), carrier);
+    },
+
+    extract: (carrier) => propagation.extract(ROOT_CONTEXT, carrier ?? {}),
+  };
+}

--- a/packages/telemetry/src/Otlp.ts
+++ b/packages/telemetry/src/Otlp.ts
@@ -1,0 +1,90 @@
+import type { PushMetricExporter } from '@opentelemetry/sdk-metrics';
+import type { SpanExporter } from '@opentelemetry/sdk-trace-base';
+
+/**
+ * OTLP serialization and exporters.
+ *
+ * The serializers turn collected signals into the OTLP/JSON wire format without
+ * sending them anywhere, which is what a consumer that ships its own transport
+ * needs - `@vercube/devtools` pushes them over its own bus.
+ *
+ * The exporters themselves live in optional peer dependencies, because they
+ * pull a protobuf stack that an application doing purely local tracing has no
+ * use for. They are loaded lazily, so their absence produces an actionable
+ * message rather than a module-resolution error at import time.
+ */
+export { JsonMetricsSerializer, JsonTraceSerializer } from '@opentelemetry/otlp-transformer';
+
+/**
+ * Where and how to reach an OTLP/HTTP collector.
+ */
+export interface OtlpExporterOptions {
+  /** OTLP/HTTP endpoint root, e.g. `http://localhost:4318`. */
+  endpoint: string;
+
+  /** Headers sent with every request, for authenticated collectors. */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Builds an OTLP/HTTP span exporter.
+ *
+ * @param options - Endpoint and headers
+ * @returns The exporter
+ * @throws When `@opentelemetry/exporter-trace-otlp-http` is not installed
+ */
+export async function createOtlpTraceExporter(options: OtlpExporterOptions): Promise<SpanExporter> {
+  let module: { OTLPTraceExporter: new (config: { url: string; headers?: Record<string, string> }) => SpanExporter };
+
+  try {
+    module = await import('@opentelemetry/exporter-trace-otlp-http');
+  } catch {
+    throw new Error(
+      'An OTLP endpoint is configured but @opentelemetry/exporter-trace-otlp-http is not installed. ' +
+        'Install it, or pass your own `exporter` to startNodeTelemetry().',
+    );
+  }
+
+  return new module.OTLPTraceExporter({
+    url: signalUrl(options.endpoint, 'traces'),
+    headers: options.headers,
+  });
+}
+
+/**
+ * Builds an OTLP/HTTP metric exporter.
+ *
+ * @param options - Endpoint and headers
+ * @returns The exporter
+ * @throws When `@opentelemetry/exporter-metrics-otlp-http` is not installed
+ */
+export async function createOtlpMetricExporter(options: OtlpExporterOptions): Promise<PushMetricExporter> {
+  let module: {
+    OTLPMetricExporter: new (config: { url: string; headers?: Record<string, string> }) => PushMetricExporter;
+  };
+
+  try {
+    module = await import('@opentelemetry/exporter-metrics-otlp-http');
+  } catch {
+    throw new Error(
+      'An OTLP endpoint is configured for metrics but @opentelemetry/exporter-metrics-otlp-http is not installed. ' +
+        'Install it, or pass your own reader to addMetricReader().',
+    );
+  }
+
+  return new module.OTLPMetricExporter({
+    url: signalUrl(options.endpoint, 'metrics'),
+    headers: options.headers,
+  });
+}
+
+/**
+ * Joins an endpoint root with an OTLP signal path.
+ *
+ * @param endpoint - Endpoint root, with or without a trailing slash
+ * @param signal - The signal path segment
+ * @returns The full URL
+ */
+function signalUrl(endpoint: string, signal: 'metrics' | 'traces'): string {
+  return `${endpoint.replace(/\/$/, '')}/v1/${signal}`;
+}

--- a/packages/telemetry/src/Sdk.ts
+++ b/packages/telemetry/src/Sdk.ts
@@ -9,12 +9,30 @@ import {
   ParentBasedSampler,
   TraceIdRatioBasedSampler,
 } from '@opentelemetry/sdk-trace-node';
+import { createOtlpTraceExporter } from './Otlp';
 import { CompositeSpanProcessor } from './Sdk/Composite';
 import type { IMetricReader } from '@opentelemetry/sdk-metrics';
 import type { Sampler, SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-node';
+import type { TelemetryTypes } from '@vercube/core';
 
 export { CompositeSpanProcessor } from './Sdk/Composite';
-import type { TelemetryTypes } from '@vercube/core';
+
+// The SDK surface a consumer needs to build its own pipeline, re-exported so
+// `@vercube/telemetry` stays the only package in the framework that declares an
+// `@opentelemetry/*` dependency. `SdkSpan` is renamed because the SDK's mutable
+// `Span` class collides with the API's `Span` interface, and the two are not
+// interchangeable.
+export {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+export type { IMetricReader, PushMetricExporter, ResourceMetrics } from '@opentelemetry/sdk-metrics';
+export { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+export type { ReadableSpan, Span as SdkSpan, SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+export { BatchSpanProcessor, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+export type { Sampler } from '@opentelemetry/sdk-trace-node';
 
 /**
  * Options for {@link startNodeTelemetry}.
@@ -166,10 +184,6 @@ export function ensureTracerProvider(options: NodeTelemetryOptions = {}): NodeTe
 /**
  * Builds the OTLP/HTTP exporter, when an endpoint is configured.
  *
- * The exporter package is an optional peer dependency, so it is required
- * lazily and its absence produces an actionable message rather than a
- * module-resolution error at import time.
- *
  * @param options - The telemetry options
  * @returns The exporter, or undefined when no endpoint is configured
  */
@@ -180,21 +194,7 @@ async function createOtlpExporter(options: NodeTelemetryOptions): Promise<SpanEx
     return undefined;
   }
 
-  let module: { OTLPTraceExporter: new (config: { url: string; headers?: Record<string, string> }) => SpanExporter };
-
-  try {
-    module = await import('@opentelemetry/exporter-trace-otlp-http');
-  } catch {
-    throw new Error(
-      'An OTLP endpoint is configured but @opentelemetry/exporter-trace-otlp-http is not installed. ' +
-        'Install it, or pass your own `exporter` to startNodeTelemetry().',
-    );
-  }
-
-  return new module.OTLPTraceExporter({
-    url: `${endpoint.replace(/\/$/, '')}/v1/traces`,
-    headers: options.headers,
-  });
+  return createOtlpTraceExporter({ endpoint, headers: options.headers });
 }
 
 /**

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,44 +1,16 @@
-// Public API
-export * from './Bootstrap/BootstrapSpans';
-export * from './Common/Attributes';
-export * from './Common/BodyCapture';
-export * from './Common/HeaderCapture';
-export * from './Common/Propagation';
-export * from './Common/SpanUtils';
-export * from './Common/Telemetry';
-export * from './Context/VercubeContextManager';
-export * from './Hooks/CoreTelemetryHooks';
-export * from './Hooks/TraceCorrelation';
-export * from './Metrics/ProcessMetrics';
-export * from './Plugins/TelemetryPlugin';
-export * from './Service/OtelTelemetry';
-
-// Re-exported so applications can annotate spans without adding a direct
-// dependency on the OpenTelemetry API package.
-export {
-  context,
-  metrics,
-  propagation,
-  ROOT_CONTEXT,
-  SpanKind,
-  SpanStatusCode,
-  trace,
-  TraceFlags,
-  ValueType,
-} from '@opentelemetry/api';
-export type {
-  Attributes,
-  Context,
-  Counter,
-  Histogram,
-  Link,
-  Meter,
-  Span,
-  SpanContext,
-  SpanOptions,
-  TextMapGetter,
-  TextMapPropagator,
-  TextMapSetter,
-  Tracer,
-  UpDownCounter,
-} from '@opentelemetry/api';
+/**
+ * The application-facing entry point: the DI token and the plugin.
+ *
+ * Everything else the package publishes lives on a subpath of its own, so an
+ * import says what it reaches for and the framework's internals are not part of
+ * the public surface:
+ *
+ * - `@vercube/telemetry/api` - the OpenTelemetry API
+ * - `@vercube/telemetry/attributes` - span and metric attribute keys
+ * - `@vercube/telemetry/instrument` - the toolkit for instrumenting a library
+ * - `@vercube/telemetry/sdk` - tracer and meter provider wiring
+ * - `@vercube/telemetry/otlp` - OTLP serializers and exporters
+ * - `@vercube/telemetry/testing` - in-memory providers for tests
+ */
+export { Telemetry } from './Common/Telemetry';
+export { TelemetryPlugin } from './Plugins/TelemetryPlugin';

--- a/packages/telemetry/test/Instrument.test.ts
+++ b/packages/telemetry/test/Instrument.test.ts
@@ -1,0 +1,152 @@
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { createInstrument } from '../src/Instrument/Factory';
+import { createTestTelemetry } from '../src/Testing';
+import type { TestTelemetry } from '../src/Testing';
+
+describe('createInstrument', () => {
+  let telemetry: TestTelemetry;
+  let instrument: ReturnType<typeof createInstrument>;
+
+  beforeAll(() => {
+    telemetry = createTestTelemetry();
+    instrument = createInstrument('@vercube/test');
+  });
+
+  afterEach(() => telemetry.reset());
+  afterAll(() => telemetry.shutdown());
+
+  describe('span', () => {
+    it('returns a synchronous result without making it a promise', () => {
+      const result = instrument.span('sync.work', { kind: SpanKind.CLIENT }, () => 21 * 2);
+
+      expect(result).toBe(42);
+      expect(telemetry.span('sync.work')?.kind).toBe(SpanKind.CLIENT);
+    });
+
+    it('ends the span when the work throws synchronously', () => {
+      expect(() =>
+        instrument.span('sync.boom', {}, () => {
+          throw new Error('nope');
+        }),
+      ).toThrow('nope');
+
+      const span = telemetry.span('sync.boom');
+
+      expect(span?.endTime).toBeDefined();
+      expect(span?.status.code).toBe(SpanStatusCode.ERROR);
+    });
+
+    it('passes an asynchronous result through and records the attributes', async () => {
+      const result = await instrument.span(
+        'async.work',
+        { kind: SpanKind.CLIENT, attributes: { 'test.key': 'value' } },
+        async () => 'done',
+      );
+
+      expect(result).toBe('done');
+      expect(telemetry.span('async.work')?.attributes['test.key']).toBe('value');
+    });
+
+    it('marks a rejection as failed', async () => {
+      await expect(instrument.span('async.boom', {}, () => Promise.reject(new Error('async nope')))).rejects.toThrow(
+        'async nope',
+      );
+
+      const span = telemetry.span('async.boom');
+
+      expect(span?.status.code).toBe(SpanStatusCode.ERROR);
+      expect(span?.status.message).toBe('async nope');
+      expect(span?.attributes['error.type']).toBe('Error');
+      expect(span?.events.some((event) => event.name === 'exception')).toBe(true);
+    });
+
+    // The server-span policy in `failSpan` deliberately leaves a 4xx unmarked,
+    // because on a server span it describes the caller. A client span has no
+    // such rule: an S3 error carrying `status: 404` is a real failure of that
+    // operation, and treating it otherwise would hide it.
+    it('marks a client-span failure even when the error carries a 4xx status', async () => {
+      const error = Object.assign(new Error('missing'), { status: 404, name: 'NotFoundError' });
+
+      await expect(instrument.span('client.missing', { kind: SpanKind.CLIENT }, () => Promise.reject(error))).rejects.toThrow(
+        'missing',
+      );
+
+      const span = telemetry.span('client.missing');
+
+      expect(span?.status.code).toBe(SpanStatusCode.ERROR);
+      expect(span?.attributes['error.type']).toBe('NotFoundError');
+    });
+
+    it('nests a span in the one that is already active', async () => {
+      await instrument.span('outer', {}, () => instrument.span('inner', {}, async () => undefined));
+
+      const outer = telemetry.span('outer');
+      const inner = telemetry.span('inner');
+
+      expect(inner?.parentSpanContext?.spanId).toBe(outer?.spanContext().spanId);
+      expect(inner?.spanContext().traceId).toBe(outer?.spanContext().traceId);
+    });
+  });
+
+  describe('spanFrom', () => {
+    it('parents the span on an extracted context rather than the active one', async () => {
+      const headers: Record<string, string> = {};
+
+      const published = await instrument.span('publish', {}, async () => {
+        instrument.inject(headers);
+
+        return instrument.activeSpan()!.spanContext();
+      });
+
+      expect(headers.traceparent).toContain(published.traceId);
+
+      // Outside any active span, exactly as a worker in another process is.
+      await instrument.spanFrom('process', {}, instrument.extract(headers), async () => undefined);
+
+      const processed = telemetry.span('process');
+
+      expect(processed?.parentSpanContext?.spanId).toBe(published.spanId);
+      expect(processed?.spanContext().traceId).toBe(published.traceId);
+    });
+
+    it('starts a root span when there is no trace context to continue', async () => {
+      await instrument.spanFrom('orphan', {}, instrument.extract(undefined), async () => undefined);
+
+      expect(telemetry.span('orphan')?.parentSpanContext).toBeUndefined();
+    });
+  });
+
+  describe('instruments', () => {
+    it('hands back the same instrument for the same name', () => {
+      expect(instrument.counter('test.counter')).toBe(instrument.counter('test.counter'));
+      expect(instrument.upDownCounter('test.updown')).toBe(instrument.upDownCounter('test.updown'));
+      expect(instrument.histogram('test.histogram')).toBe(instrument.histogram('test.histogram'));
+    });
+
+    it('reports what a counter recorded', async () => {
+      instrument.counter('test.recorded', { unit: '{thing}' }).add(3, { 'test.label': 'a' });
+
+      const batches = await telemetry.collect();
+      const metric = batches
+        .at(-1)
+        ?.scopeMetrics.flatMap((scope) => scope.metrics)
+        .find((entry) => entry.descriptor.name === 'test.recorded');
+
+      expect(metric?.dataPoints[0]?.value).toBe(3);
+      expect(metric?.dataPoints[0]?.attributes['test.label']).toBe('a');
+    });
+  });
+
+  describe('activeSpan', () => {
+    it('is undefined outside a span', () => {
+      expect(instrument.activeSpan()).toBeUndefined();
+    });
+
+    it('is the innermost span inside one', () => {
+      instrument.span('named', {}, (span) => {
+        expect(instrument.activeSpan()).toBe(span);
+      });
+    });
+  });
+});

--- a/packages/telemetry/tsdown.config.ts
+++ b/packages/telemetry/tsdown.config.ts
@@ -5,5 +5,13 @@ import defaultConfig from '../../tsdown.config.ts';
 // return config for tsdown
 export default defineConfig({
   ...defaultConfig,
-  entry: ['./src/index.ts', './src/Sdk.ts', './src/Testing.ts'],
+  entry: [
+    './src/index.ts',
+    './src/Api.ts',
+    './src/Attributes.ts',
+    './src/Instrument.ts',
+    './src/Otlp.ts',
+    './src/Sdk.ts',
+    './src/Testing.ts',
+  ],
 });

--- a/packages/vite/src/env.ts
+++ b/packages/vite/src/env.ts
@@ -21,6 +21,10 @@ export const FRAMEWORK_RUNTIME_DEPS: (string | RegExp)[] = [
   'evlog',
   /^evlog\//,
   '@standard-schema/spec',
+  // Runtime dependencies of `@vercube/telemetry`, which every instrumented
+  // package reaches through. Only that package declares them, so an app that
+  // does not depend on it directly has them nested and unresolvable from root.
+  /^@opentelemetry\//,
 ];
 
 /**
@@ -31,7 +35,17 @@ export const FRAMEWORK_RUNTIME_DEPS: (string | RegExp)[] = [
 export const DEFAULT_NO_EXTERNAL: (string | RegExp)[] = [/^@vercube\//, ...FRAMEWORK_RUNTIME_DEPS];
 
 /** Vercube packages that must resolve to a single module id (class-reference DI tokens). */
-export const VERCUBE_PACKAGES = ['@vercube/core', '@vercube/di', '@vercube/auth', '@vercube/logger', '@vercube/schema'] as const;
+export const VERCUBE_PACKAGES = [
+  '@vercube/core',
+  '@vercube/di',
+  '@vercube/auth',
+  '@vercube/logger',
+  '@vercube/schema',
+  // `Telemetry` is a class-reference token, and this package now enters the
+  // graph from every instrumented package at once. Two copies of it mean
+  // `@Inject(Telemetry)` resolves against a binding that was never made.
+  '@vercube/telemetry',
+] as const;
 
 /**
  * Canonical entry paths for `@vercube/*` packages from the consuming app's root.

--- a/packages/vite/src/env.ts
+++ b/packages/vite/src/env.ts
@@ -67,6 +67,43 @@ export function createVercubeResolveAliases(root: string): Record<string, string
   return aliases;
 }
 
+/**
+ * The same canonical entries in the form `resolve.alias` needs.
+ *
+ * A string `find` in Vite's alias config is a **prefix** match: it matches the
+ * bare specifier and anything under it, and the replacement is a plain
+ * `String.replace`. Mapping `'@vercube/telemetry'` to `.../dist/index.mjs`
+ * would therefore rewrite `@vercube/telemetry/instrument` into
+ * `.../dist/index.mjs/instrument`, which resolves to nothing. Every subpath
+ * export in the workspace is affected: `@vercube/telemetry/instrument` is what
+ * six instrumented packages import, and `@vercube/logger/toolkit` is what core
+ * imports.
+ *
+ * An anchored `RegExp` matches the package root and nothing below it, so a
+ * subpath falls through to normal resolution. `$` in the *replacement* is
+ * escaped separately, because `String.replace` reads `$&` and friends as
+ * capture references there.
+ *
+ * @param root - The consuming app's root
+ * @returns Alias entries safe to hand to `resolve.alias`
+ */
+export function createVercubeAliasEntries(root: string): { find: RegExp; replacement: string }[] {
+  return Object.entries(createVercubeResolveAliases(root)).map(([name, entry]) => ({
+    find: new RegExp(`^${escapeRegExp(name)}$`),
+    replacement: entry.replaceAll('$', '$$$$'),
+  }));
+}
+
+/**
+ * Escapes the characters that would otherwise be read as pattern syntax.
+ *
+ * @param value - The literal to match
+ * @returns The escaped literal
+ */
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
+}
+
 /** @deprecated Use {@link DEFAULT_NO_EXTERNAL}. */
 export const DEV_NO_EXTERNAL = DEFAULT_NO_EXTERNAL;
 

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -1,7 +1,7 @@
 import { defu } from 'defu';
 import { resolve } from 'pathe';
 import { CLIENT_OUT_DIR, createContext, setupContext } from './context';
-import { createVercubeEnvironment, createVercubeResolveAliases, initEnvRunner } from './env';
+import { createVercubeAliasEntries, createVercubeEnvironment, createVercubeResolveAliases, initEnvRunner } from './env';
 import { VERCUBE_ENV } from './types';
 import type { VercubePluginConfig, VercubePluginContext } from './types';
 import type { Plugin } from 'vite';
@@ -54,7 +54,7 @@ function vercubeMain(ctx: VercubePluginContext): Plugin {
       return {
         builder: { sharedConfigBuild: true },
         resolve: {
-          alias: createVercubeResolveAliases(ctx.root),
+          alias: createVercubeAliasEntries(ctx.root),
         },
         environments: {
           client: { build: { outDir: resolve(ctx.root, CLIENT_OUT_DIR) } },

--- a/packages/vite/test/env.test.ts
+++ b/packages/vite/test/env.test.ts
@@ -31,6 +31,7 @@ vi.mock('env-runner', async (importOriginal) => {
 import {
   createProdExternal,
   createVercubeEnvironment,
+  createVercubeAliasEntries,
   createVercubeResolveAliases,
   DEFAULT_NO_EXTERNAL,
   DEV_NO_EXTERNAL,
@@ -154,6 +155,50 @@ describe('createVercubeResolveAliases', () => {
 
     expect(aliases['@vercube/core']).toContain('packages/core');
     expect(aliases['@vercube/di']).toContain('packages/di');
+  });
+});
+
+describe('createVercubeAliasEntries', () => {
+  const root = resolve(process.cwd(), '../..');
+
+  /**
+   * How Vite resolves `resolve.alias`, copied from `@rollup/plugin-alias`: a
+   * string `find` is a prefix match and the replacement is a `String.replace`.
+   * Replicated here because the bug this guards against is invisible from the
+   * outside - the specifier is silently rewritten into a path that does not
+   * exist - and only shows up as a resolution failure in a consuming app.
+   *
+   * @param entries - The alias entries under test
+   * @param importee - The specifier being imported
+   * @returns The rewritten specifier, or undefined when no entry matched
+   */
+  function resolveAlias(entries: { find: RegExp; replacement: string }[], importee: string): string | undefined {
+    const matched = entries.find((entry) => entry.find.test(importee));
+
+    return matched ? importee.replace(matched.find, matched.replacement) : undefined;
+  }
+
+  it('pins each package root to a single resolved entry', () => {
+    const entries = createVercubeAliasEntries(root);
+
+    expect(resolveAlias(entries, '@vercube/core')).toContain('packages/core');
+    expect(resolveAlias(entries, '@vercube/di')).toContain('packages/di');
+  });
+
+  it('leaves subpath exports alone', () => {
+    const entries = createVercubeAliasEntries(root);
+
+    // A prefix-matching alias would rewrite these to `dist/index.mjs/instrument`
+    // and break every instrumented package.
+    expect(resolveAlias(entries, '@vercube/telemetry/instrument')).toBeUndefined();
+    expect(resolveAlias(entries, '@vercube/telemetry/sdk')).toBeUndefined();
+    expect(resolveAlias(entries, '@vercube/logger/toolkit')).toBeUndefined();
+  });
+
+  it('does not alias a package that only shares a prefix', () => {
+    const entries = createVercubeAliasEntries(root);
+
+    expect(resolveAlias(entries, '@vercube/core-extras')).toBeUndefined();
   });
 });
 

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -29,10 +29,10 @@
     "zod": "catalog:"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.9.1",
     "@vercube/core": "workspace:*",
     "@vercube/di": "workspace:*",
     "@vercube/logger": "workspace:*",
+    "@vercube/telemetry": "workspace:*",
     "crossws": "0.4.12",
     "srvx": "catalog:"
   },

--- a/packages/ws/src/Services/WebsocketService.ts
+++ b/packages/ws/src/Services/WebsocketService.ts
@@ -1,12 +1,12 @@
-import { context, metrics, SpanKind, trace, ValueType } from '@opentelemetry/api';
 import { BadRequestError, HttpServer, ValidationProvider, safeJsonParse, sanitizeObject } from '@vercube/core';
 import { Inject, InjectOptional } from '@vercube/di';
 import { Logger } from '@vercube/logger';
+import { createInstrument, SpanKind, ValueType } from '@vercube/telemetry/instrument';
 import { defineHooks } from 'crossws';
 import { plugin } from 'crossws/server';
 import { WebsocketTypes } from '../Types/WebsocketTypes';
 import type { WSError, WSMessage, WSPeer } from '../Types/WebsocketTypes';
-import type { Span, UpDownCounter } from '@opentelemetry/api';
+import type { Span } from '@vercube/telemetry/instrument';
 import type { NodeAdapter } from 'crossws/adapters/node';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
@@ -28,11 +28,16 @@ type WsUpgradeGlobal = { __vercube_ws_upgrade__?: (req: IncomingMessage, socket:
  * - Registering namespaces and accepting websocket connections for them
  * - Registering event handlers and handling them
  */
-/** Instrumentation scope reported for websocket signals. */
-const SCOPE = '@vercube/ws';
+/**
+ * Records websocket signals.
+ *
+ * The toolkit comes from `@vercube/telemetry/instrument`, which is the only
+ * place in the framework that speaks to OpenTelemetry directly.
+ */
+const instrument = createInstrument('@vercube/ws');
 
-/** Lazily created gauge of currently connected peers. */
-let connections: UpDownCounter | undefined;
+/** Attribute naming the namespace a peer or message belongs to. */
+const WS_NAMESPACE = 'vercube.ws.namespace';
 
 /**
  * Records a change in the number of connected peers.
@@ -46,13 +51,13 @@ let connections: UpDownCounter | undefined;
  * @returns {void}
  */
 function countConnection(delta: number, namespace: string): void {
-  connections ??= metrics.getMeter(SCOPE).createUpDownCounter('vercube.ws.connections', {
-    description: 'Currently connected websocket peers.',
-    unit: '{connection}',
-    valueType: ValueType.INT,
-  });
-
-  connections.add(delta, { 'vercube.ws.namespace': namespace });
+  instrument
+    .upDownCounter('vercube.ws.connections', {
+      description: 'Currently connected websocket peers.',
+      unit: '{connection}',
+      valueType: ValueType.INT,
+    })
+    .add(delta, { [WS_NAMESPACE]: namespace });
 }
 
 export class WebsocketService {
@@ -287,15 +292,11 @@ export class WebsocketService {
     // A websocket message is work the server does on its own behalf, so it gets
     // a CONSUMER span of its own rather than hanging off whatever request
     // happened to open the socket.
-    const span = trace
-      .getTracer(SCOPE)
-      .startSpan('ws.message', { kind: SpanKind.CONSUMER, attributes: { 'vercube.ws.namespace': peer.namespace ?? '' } });
-
-    try {
-      await context.with(trace.setSpan(context.active(), span), () => this.internalHandleMessage(peer, rawMessage, span));
-    } finally {
-      span.end();
-    }
+    await instrument.span(
+      'ws.message',
+      { kind: SpanKind.CONSUMER, attributes: { [WS_NAMESPACE]: peer.namespace ?? '' } },
+      (span) => this.internalHandleMessage(peer, rawMessage, span),
+    );
   }
 
   /**

--- a/playground/package.json
+++ b/playground/package.json
@@ -25,6 +25,7 @@
     "@vercube/schema": "workspace:*",
     "@vercube/serverless": "workspace:*",
     "@vercube/storage": "workspace:*",
+    "@vercube/telemetry": "workspace:*",
     "@vercube/ws": "workspace:*",
     "serverless": "4.41.1",
     "serverless-offline": "14.8.2",

--- a/playground/test/TelemetryPropagation.integration.test.ts
+++ b/playground/test/TelemetryPropagation.integration.test.ts
@@ -1,0 +1,73 @@
+import { Controller, createApp, Get } from '@vercube/core';
+import { Inject } from '@vercube/di';
+import { StorageManager } from '@vercube/storage';
+import { MemoryStorage } from '@vercube/storage/drivers/MemoryStorage';
+import { TelemetryPlugin } from '@vercube/telemetry';
+import { createTestTelemetry } from '@vercube/telemetry/testing';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { App } from '@vercube/core';
+import type { TestTelemetry } from '@vercube/telemetry/testing';
+
+/**
+ * Every instrumented package reaches OpenTelemetry through
+ * `@vercube/telemetry/instrument` rather than depending on it directly. That
+ * indirection is only correct if the active context still crosses it, so this
+ * asserts the thing that would break silently: a storage span produced from a
+ * request handler has to land under that request's server span.
+ */
+@Controller('/telemetry')
+class TelemetryController {
+  @Inject(StorageManager)
+  private gStorage!: StorageManager;
+
+  @Get('/item')
+  public async item(): Promise<{ value: string | null }> {
+    await this.gStorage.setItem({ key: 'probe', value: 'value' });
+
+    return { value: await this.gStorage.getItem<string>({ key: 'probe' }) };
+  }
+}
+
+describe('telemetry propagation across packages', () => {
+  let telemetry: TestTelemetry;
+  let app: App;
+
+  beforeAll(async () => {
+    telemetry = createTestTelemetry();
+
+    app = await createApp({
+      cfg: { telemetry: { enabled: true, spans: { di: false } }, requestLogging: false },
+      setup: (instance) => {
+        instance.container.bind(StorageManager);
+        instance.container.bind(TelemetryController);
+        instance.addPlugin(TelemetryPlugin);
+      },
+    });
+
+    await app.container.get(StorageManager).mount({ storage: MemoryStorage });
+  });
+
+  afterAll(() => telemetry.shutdown());
+
+  it('nests storage spans under the server span that caused them', async () => {
+    const response = await app.fetch(new Request('http://localhost/telemetry/item'));
+
+    expect(response.status).toBe(200);
+    await telemetry.settle();
+
+    const server = telemetry.span('GET /telemetry/item');
+    const setItem = telemetry.span('storage.setItem');
+    const getItem = telemetry.span('storage.getItem');
+
+    expect(server).toBeDefined();
+    expect(setItem).toBeDefined();
+    expect(getItem).toBeDefined();
+
+    // Same trace, and parented on the handler span nested in the server span
+    // rather than floating as roots of their own.
+    expect(setItem?.spanContext().traceId).toBe(server?.spanContext().traceId);
+    expect(getItem?.spanContext().traceId).toBe(server?.spanContext().traceId);
+    expect(setItem?.parentSpanContext?.spanId).toBeDefined();
+    expect(getItem?.parentSpanContext?.spanId).toBeDefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,9 +423,6 @@ importers:
 
   packages/auth:
     dependencies:
-      '@opentelemetry/api':
-        specifier: 1.9.1
-        version: 1.9.1
       '@vercube/core':
         specifier: workspace:*
         version: link:../core
@@ -435,12 +432,12 @@ importers:
       '@vercube/logger':
         specifier: workspace:*
         version: link:../logger
+      '@vercube/telemetry':
+        specifier: workspace:*
+        version: link:../telemetry
 
   packages/cache:
     dependencies:
-      '@opentelemetry/api':
-        specifier: 1.9.1
-        version: 1.9.1
       '@vercube/di':
         specifier: workspace:*
         version: link:../di
@@ -450,6 +447,9 @@ importers:
       '@vercube/storage':
         specifier: workspace:*
         version: link:../storage
+      '@vercube/telemetry':
+        specifier: workspace:*
+        version: link:../telemetry
       ocache:
         specifier: 'catalog:'
         version: 0.3.0
@@ -460,9 +460,6 @@ importers:
       '@vercube/core':
         specifier: workspace:*
         version: link:../core
-      '@vercube/telemetry':
-        specifier: workspace:*
-        version: link:../telemetry
 
   packages/cli:
     dependencies:
@@ -593,24 +590,6 @@ importers:
 
   packages/devtools:
     dependencies:
-      '@opentelemetry/api':
-        specifier: 1.9.1
-        version: 1.9.1
-      '@opentelemetry/otlp-transformer':
-        specifier: 0.222.0
-        version: 0.222.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources':
-        specifier: 2.11.0
-        version: 2.11.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics':
-        specifier: 2.11.0
-        version: 2.11.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base':
-        specifier: 2.11.0
-        version: 2.11.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-node':
-        specifier: 2.11.0
-        version: 2.11.0(@opentelemetry/api@1.9.1)
       '@vercube/core':
         specifier: workspace:*
         version: link:../core
@@ -683,9 +662,6 @@ importers:
 
   packages/queue:
     dependencies:
-      '@opentelemetry/api':
-        specifier: 1.9.1
-        version: 1.9.1
       '@vercube/core':
         specifier: workspace:*
         version: link:../core
@@ -695,7 +671,6 @@ importers:
       '@vercube/logger':
         specifier: workspace:*
         version: link:../logger
-    devDependencies:
       '@vercube/telemetry':
         specifier: workspace:*
         version: link:../telemetry
@@ -770,16 +745,12 @@ importers:
 
   packages/storage:
     dependencies:
-      '@opentelemetry/api':
-        specifier: 1.9.1
-        version: 1.9.1
       '@vercube/di':
         specifier: workspace:*
         version: link:../di
       '@vercube/logger':
         specifier: workspace:*
         version: link:../logger
-    devDependencies:
       '@vercube/telemetry':
         specifier: workspace:*
         version: link:../telemetry
@@ -793,20 +764,7 @@ importers:
       '@opentelemetry/api':
         specifier: 1.9.1
         version: 1.9.1
-      '@opentelemetry/exporter-metrics-otlp-http':
-        specifier: ^0.222.0
-        version: 0.222.0(@opentelemetry/api@1.9.1)
-      '@vercube/core':
-        specifier: workspace:*
-        version: link:../core
-      '@vercube/di':
-        specifier: workspace:*
-        version: link:../di
-      '@vercube/logger':
-        specifier: workspace:*
-        version: link:../logger
-    devDependencies:
-      '@opentelemetry/exporter-trace-otlp-http':
+      '@opentelemetry/otlp-transformer':
         specifier: 0.222.0
         version: 0.222.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources':
@@ -821,6 +779,22 @@ importers:
       '@opentelemetry/sdk-trace-node':
         specifier: 2.11.0
         version: 2.11.0(@opentelemetry/api@1.9.1)
+      '@vercube/core':
+        specifier: workspace:*
+        version: link:../core
+      '@vercube/di':
+        specifier: workspace:*
+        version: link:../di
+      '@vercube/logger':
+        specifier: workspace:*
+        version: link:../logger
+    devDependencies:
+      '@opentelemetry/exporter-metrics-otlp-http':
+        specifier: 0.222.0
+        version: 0.222.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: 0.222.0
+        version: 0.222.0(@opentelemetry/api@1.9.1)
 
   packages/vite:
     dependencies:
@@ -852,9 +826,6 @@ importers:
 
   packages/ws:
     dependencies:
-      '@opentelemetry/api':
-        specifier: 1.9.1
-        version: 1.9.1
       '@vercube/core':
         specifier: workspace:*
         version: link:../core
@@ -864,6 +835,9 @@ importers:
       '@vercube/logger':
         specifier: workspace:*
         version: link:../logger
+      '@vercube/telemetry':
+        specifier: workspace:*
+        version: link:../telemetry
       crossws:
         specifier: 0.4.12
         version: 0.4.12(srvx@1.0.3)
@@ -904,6 +878,9 @@ importers:
       '@vercube/storage':
         specifier: workspace:*
         version: link:../packages/storage
+      '@vercube/telemetry':
+        specifier: workspace:*
+        version: link:../packages/telemetry
       '@vercube/ws':
         specifier: workspace:*
         version: link:../packages/ws

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,15 @@
     "lib": ["dom", "es6", "es2017", "es2019", "ESNext"],
     "typeRoots": ["node_modules/@types"],
     "paths": {
+      // The wildcard below only resolves bare package roots, so a subpath
+      // export would fall through to node_modules and require a built `dist`.
+      // Mapped explicitly so a clean clone typechecks before anything is built.
+      "@vercube/telemetry/api": ["./packages/telemetry/src/Api.ts"],
+      "@vercube/telemetry/attributes": ["./packages/telemetry/src/Attributes.ts"],
+      "@vercube/telemetry/instrument": ["./packages/telemetry/src/Instrument.ts"],
+      "@vercube/telemetry/otlp": ["./packages/telemetry/src/Otlp.ts"],
+      "@vercube/telemetry/sdk": ["./packages/telemetry/src/Sdk.ts"],
+      "@vercube/telemetry/testing": ["./packages/telemetry/src/Testing.ts"],
       "@vercube/*": ["./packages/*/src"]
     }
   },


### PR DESCRIPTION
## Why

`@opentelemetry/api` was a direct dependency of **six** packages (`auth`, `cache`, `storage`, `queue`, `ws`, `telemetry`), and `devtools` carried five SDK packages of its own, two of which (`resources`, `sdk-trace-node`) were never imported anywhere.

The facade meant to prevent exactly this already existed in `@vercube/telemetry` and was bypassed everywhere. Its comment even said so:

> Re-exported so applications can annotate spans without adding a direct dependency on the OpenTelemetry API package.

Nobody used it, and it was missing `Exception`, `createTraceState` and `isSpanContextValid`, so a full migration would have needed extending it anyway. Meanwhile the same `fail(span, error)` had been copied verbatim into three packages and `settle(span, parent, fn)` into two.

Docs also told users to install three `@opentelemetry/*` packages by hand.

## What changed

`@opentelemetry/*` now appears in **exactly one** `package.json`:

```console
$ grep -rl '"@opentelemetry/' --include=package.json packages playground examples docs
packages/telemetry/package.json
```

Outside `packages/telemetry/src`, no `.ts` file in the repo imports from `@opentelemetry/*`.

### One entry point per job, instead of one barrel

| Import | For |
| --- | --- |
| `@vercube/telemetry` | the `Telemetry` token and `TelemetryPlugin`, and nothing else |
| `@vercube/telemetry/api` | the OpenTelemetry API, re-exported in full |
| `@vercube/telemetry/attributes` | span and metric attribute keys |
| `@vercube/telemetry/instrument` | `createInstrument`, for instrumenting a library |
| `@vercube/telemetry/sdk` | provider wiring plus the SDK classes and types |
| `@vercube/telemetry/otlp` | OTLP serializers and lazy exporter factories |
| `@vercube/telemetry/testing` | in-memory providers for tests |

`/api` is `export * from '@opentelemetry/api'` rather than a hand-picked list. A curated slice is permanent maintenance debt, and the old one had already fallen behind.

### The framework consumes its own facade

`storage`, `cache`, `queue`, `auth` and `ws` instrument themselves through `@vercube/telemetry/instrument`. `devtools` reads spans through `/api`, `/sdk`, `/attributes` and `/otlp`, and drops all six of its own OTel dependencies.

The "framework-free `@vercube/storage`" claim is given up deliberately: it depends on `@vercube/telemetry` now, which depends on `@vercube/core`. No cycle, since core depends on no leaf package.

### One installation

The OTel SDK (`resources`, `sdk-trace-base`, `sdk-trace-node`, `sdk-metrics`, `otlp-transformer`) moves from optional peers into `dependencies`, so `pnpm add @vercube/telemetry` is the whole installation: providers, samplers and the in-memory test providers all ship with it. Only the two OTLP **exporters** stay optional peers, because they pull a protobuf stack an application doing purely local tracing has no use for.

As a side effect of `deps.neverBundle` being derived from `dependencies`, the SDK is now externalized from `dist/Sdk.mjs` instead of bundled into it.

### Deduplication

`fail()` and `settle()` are gone from every leaf package. `storage/src/Common/Instrument.ts` went from 60 lines to 26.

## Two correctness notes

**`recordFailure` is split out from `failSpan`.** A server span must not be ERROR for a 4xx (HTTP semconv: the caller's fault, not the handler's), but a storage error carrying `status: 404` *is* a real failure of that operation. Client, producer and consumer spans use the unconditional variant. Both carry a comment against merging them, and there is a test pinning the difference.

`runInSpan` is deliberately **not** re-exported from `/instrument`: it has the server-span policy baked in, and exposing it there would invite exactly that mistake. It also stays untouched on the hot request path.

**`@vercube/vite`** needed two additions that became load-bearing the moment an instrumented package reached OTel transitively:
- `@opentelemetry/*` in `FRAMEWORK_RUNTIME_DEPS`, since `@vercube/*` is bundled and pnpm does not hoist their nested deps to the app root.
- `@vercube/telemetry` in `VERCUBE_PACKAGES`, because `Telemetry` is a class-reference DI token that now enters the module graph from six places at once. Two copies mean `@Inject(Telemetry)` resolves against a binding that was never made.

## Tests

- `packages/telemetry/test/Instrument.test.ts` (12 cases): synchronous result stays synchronous, a synchronous throw still ends the span, rejection sets `error.type` and records the exception, a client-span failure carrying a 4xx **is** marked ERROR, `inject` → `extract` → `spanFrom` reparents across a simulated process boundary, instruments memoize by name.
- `playground/test/TelemetryPropagation.integration.test.ts`: the thing that could have broken silently. A `storage.setItem` span produced from a request handler has to land in the same trace as the server span, with a parent. It also proves the new subpaths resolve through the playground's exports-map alias, which only fails on Linux.
- `packages/{storage,cache,queue}/test/Instrumentation.test.ts` pass **unchanged**, which is the real regression gate for the leaf migration.

## Verification

- `pnpm build` — 17/17 tasks
- `pnpm test:tscheck` — clean
- `pnpm test` — 1985 tests / 165 files passing
- `pnpm test:lint` — clean
- Production builds of the playground and the `vite` example both succeed

`tsconfig.json` gained explicit `paths` for the telemetry subpaths. Without them a clean clone cannot typecheck the five leaf packages until telemetry is built, because the `@vercube/*` wildcard only resolves bare package roots.

## Breaking change

`@vercube/telemetry` no longer re-exports the OpenTelemetry API or the attribute constants from its main entry:

```diff
-import { SpanKind, trace } from '@vercube/telemetry';
+import { SpanKind, trace } from '@vercube/telemetry/api';

-import { HTTP_ROUTE } from '@vercube/telemetry';
+import { HTTP_ROUTE } from '@vercube/telemetry/attributes';
```

`import { Telemetry, TelemetryPlugin } from '@vercube/telemetry'` is unchanged.

The package's internals are no longer exported at all: `CoreTelemetryHooks`, `OtelTelemetry`, `VercubeContextManager`, `BootstrapRecorder`, body and header capture, `installProcessMetrics`, `installTraceCorrelation`, `W3CTraceContextPropagator`. None of them was documented in the API reference.

Users installing the SDK by hand can drop those packages; the exporter is the only one still needed.

## Docs

- Install instructions reduced to one command in both the docs and the package README.
- `docs/3.modules/11.telemetry/1.api.md` documents all seven entry points.
- New `docs/3.modules/11.telemetry/2.instrumentation.md` makes `/instrument` a real public contract rather than a helper that happens to be reachable: scopes, span settling, crossing a process boundary, metric cardinality, and why the active-span pattern exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public import paths and a broad refactor across observability and Vite bundling, though behavior is guarded by new instrument tests and a cross-package propagation integration test.
> 
> **Overview**
> **`@vercube/telemetry` becomes the sole owner of `@opentelemetry/*`**, with purpose-specific subpaths (`/api`, `/attributes`, `/instrument`, `/sdk`, `/otlp`, `/testing`) and a slim main entry that only exports `Telemetry` and `TelemetryPlugin`. The OTel SDK moves into telemetry dependencies; OTLP HTTP exporters stay optional peers with lazy loading via new `createOtlpTraceExporter` / `createOtlpMetricExporter`.
> 
> **Framework packages stop depending on OpenTelemetry directly.** `auth`, `cache`, `storage`, `queue`, and `ws` switch to `createInstrument` from `@vercube/telemetry/instrument`, replacing duplicated span/metric/`settle` helpers. `devtools` imports API, SDK, attributes, and OTLP serializers through telemetry. Span failure handling splits **`recordFailure`** (client/producer/consumer) from **`failSpan`** (HTTP server 5xx-only semantics).
> 
> **Docs and install guidance** describe the subpath model, add an instrumentation guide, and narrow extra installs to `@opentelemetry/exporter-trace-otlp-http`. **`@vercube/vite`** bundles nested `@opentelemetry/*`, dedupes `@vercube/telemetry` for the DI token, and uses anchored regex aliases so subpaths like `/instrument` are not broken by package-root aliasing.
> 
> **Breaking:** migrate `SpanKind`, `trace`, attribute constants, and former internal exports from `@vercube/telemetry` to the documented subpaths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd9b135383258ca5d4da899041e4df2d27070d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated telemetry entry points for APIs, attributes, instrumentation, SDK utilities, and OTLP exporters.
  * Added reusable support for spans, metrics, context propagation, and active-span access.
  * Added OTLP trace and metric exporter helpers.

* **Improvements**
  * Standardized framework packages on the shared telemetry toolkit.
  * Improved error recording and span failure handling.
  * Simplified telemetry setup and installation requirements.

* **Documentation**
  * Expanded telemetry documentation with entry-point, instrumentation, propagation, and installation guidance.

* **Tests**
  * Added coverage for instrumentation behavior and telemetry propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->